### PR TITLE
feat: refactor arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,18 @@ In CI or other non-interactive runs, add `--yes` so a missing preset name fails 
 
 ### Common flags
 
-| Flag                  | Applies to         | Description                                                                  |
-| --------------------- | ------------------ | ---------------------------------------------------------------------------- |
-| `-g`, `--global`      | all                | Operate on `~/.ulis/` and home-level install targets (`~/.claude/`…)         |
-| `--source <path>`     | `build`, `install` | Override the source directory; with `--global`, installs still target home   |
-| `--target <platform>` | `build`, `install` | Comma-separated list: `claude`, `codex`, `cursor`, `opencode`, `forgecode`   |
-| `--preset <names>`    | `build`, `install` | Apply preset(s) from `~/.ulis/presets/` or bundled presets (comma-separated) |
-| `-y`, `--yes`         | `install`          | Skip confirmation prompts                                                    |
-| `--no-rebuild`        | `install`          | Skip the build step and deploy existing `generated/`                         |
-| `--backup`            | `install`          | Back up existing platform dirs (`<dir>.backup.YYYYMMDD_HHMMSS`)              |
-| `--runner <name>`     | `install`          | Package runner for `extensions.yaml` (`npx` or `bunx`)                       |
-| `--no-extensions`     | `install`          | Skip running entries from `extensions.yaml`                                  |
+| Flag                     | Applies to         | Description                                                                  |
+| ------------------------ | ------------------ | ---------------------------------------------------------------------------- |
+| `-g`, `--global`         | all                | Operate on `~/.ulis/` and home-level install targets (`~/.claude/`…)         |
+| `--source <path>`        | `build`, `install` | Override the source directory; with `--global`, installs still target home   |
+| `--target <platforms>`   | `build`, `install` | Comma-separated list: `claude`, `codex`, `cursor`, `opencode`, `forgecode`   |
+| `--preset <names>`       | `build`, `install` | Apply preset(s) from `~/.ulis/presets/` or bundled presets (comma-separated) |
+| `-y`, `--yes`            | `install`          | Skip confirmation prompts                                                    |
+| `--skip-rebuild`         | `install`          | Skip the build step and deploy existing `generated/`                         |
+| `--backup`               | `install`          | Back up existing platform dirs (`<dir>.backup.YYYYMMDD_HHMMSS`)              |
+| `--runner <npx\|bunx>`   | `install`          | Package runner for `extensions.yaml` (`npx` or `bunx`)                       |
+| `--skip-extensions`      | `install`          | Skip running entries from `extensions.yaml`                                  |
+| `--skip-external-skills` | `install`          | Skip installing external skills declared in `skills.yaml`                    |
 
 ### Presets (quick reference)
 
@@ -265,7 +266,7 @@ claude:
 2. `runner: npx | bunx` in `config.yaml`
 3. Auto-detect: `bunx` if available on PATH, otherwise `npx`
 
-A single failing extension logs a warning and the install continues. Skip the phase entirely with `--no-extensions`. Extensions are always re-run on each install (no caching in this version — see [SPEC.md](docs/SPEC.md) for the future caching plan).
+A single failing extension logs a warning and the install continues. Skip the phase entirely with `--skip-extensions`. Extensions are always re-run on each install (no caching in this version — see [SPEC.md](docs/SPEC.md) for the future caching plan).
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,21 +72,22 @@ Run `build` and then deploy the generated configs onto the target platform direc
 
 ```bash
 ulis install [-g | --global] [--source <path>] [--target <platforms>]
-             [-y | --yes] [--no-rebuild] [--backup] [--preset <names>]
-             [--runner <npx|bunx>] [--no-extensions]
+             [-y | --yes] [--skip-rebuild] [--backup] [--preset <names>]
+             [--runner <npx|bunx>] [--skip-extensions] [--skip-external-skills]
 ```
 
-| Flag                   | Effect                                                                                                                                                     |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-g`, `--global`       | Read `~/.ulis/` and write to `~/.claude/`, `~/.codex/`, `~/.cursor/`, `~/.config/opencode/` (Windows: `%USERPROFILE%\.config\opencode\`), and `~/.forge/`. |
-| `--source <path>`      | Override source (still writes to CWD or home depending on `--global`).                                                                                     |
-| `--target <platforms>` | Only build/install the listed platforms.                                                                                                                   |
-| `-y`, `--yes`          | Skip the "about to overwrite" confirmation prompt.                                                                                                         |
-| `--no-rebuild`         | Don't rebuild — install whatever is already under `<source>/generated/`.                                                                                   |
-| `--backup`             | Copy each existing platform dir to `<dir>.backup.YYYYMMDD_HHMMSS` before writing.                                                                          |
-| `--preset <names>`     | Same resolution as `ulis build --preset` (user-global directory, then bundled).                                                                            |
-| `--runner <name>`      | Package runner used for `extensions.yaml` entries. `npx` or `bunx`. Overrides `runner` in `config.yaml`. Default: auto-detect (`bunx` if present).         |
-| `--no-extensions`      | Skip running entries from `extensions.yaml`. Useful in CI where network installs are not desired.                                                          |
+| Flag                     | Effect                                                                                                                                                     |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-g`, `--global`         | Read `~/.ulis/` and write to `~/.claude/`, `~/.codex/`, `~/.cursor/`, `~/.config/opencode/` (Windows: `%USERPROFILE%\.config\opencode\`), and `~/.forge/`. |
+| `--source <path>`        | Override source (still writes to CWD or home depending on `--global`).                                                                                     |
+| `--target <platforms>`   | Only build/install the listed platforms.                                                                                                                   |
+| `-y`, `--yes`            | Skip the "about to overwrite" confirmation prompt.                                                                                                         |
+| `--skip-rebuild`         | Don't rebuild — install whatever is already under `<source>/generated/`.                                                                                   |
+| `--backup`               | Copy each existing platform dir to `<dir>.backup.YYYYMMDD_HHMMSS` before writing.                                                                          |
+| `--preset <names>`       | Same resolution as `ulis build --preset` (user-global directory, then bundled).                                                                            |
+| `--runner <npx\|bunx>`   | Package runner used for `extensions.yaml` entries. `npx` or `bunx`. Overrides `runner` in `config.yaml`. Default: auto-detect (`bunx` if present).         |
+| `--skip-extensions`      | Skip running entries from `extensions.yaml`. Useful in CI where network installs are not desired.                                                          |
+| `--skip-external-skills` | Skip installing external skills declared in `skills.yaml`. Useful in CI where network installs are not desired.                                            |
 
 **Preset resolution:** Each name maps to a directory. ULIS checks `~/.ulis/presets/<name>/` first; if that folder is missing, it uses the matching bundled preset next to the CLI (`dist/presets/` when installed). A preset in your home tree with the same folder name **shadows** the bundled one. Multiple `--preset` values merge **left to right**, then the base source (from `--source`, `./.ulis/`, or `~/.ulis/`) is applied last — **the base wins on conflicts**. Interactive runs prompt to continue when a name is missing; with `--yes`, missing presets fail immediately.
 
@@ -133,21 +134,22 @@ ulis preset [--list]
 ulis preset list
 ulis preset install <names...> [-g | --global] [--target <platforms>]
                     [-y | --yes] [--backup] [--runner <npx|bunx>]
-                    [--no-extensions]
+                    [--skip-extensions] [--skip-external-skills]
 ```
 
 `-l` / `--list` is accepted. The default action is `list`. Each line shows the directory name (what you pass to `--preset`), a `user` or `bundled` label, optional `name` / `description` from `preset.yaml`, and the display title when it differs from the folder name.
 
 `ulis preset install <names...>` installs selected presets **without** merging a project or global source. Names may be comma-separated (`a,b`) or repeated (`a b`) and are merged in the order given. Generated output is temporary and is removed after install.
 
-| Flag                   | Effect                                                                                       |
-| ---------------------- | -------------------------------------------------------------------------------------------- |
-| `-g`, `--global`       | Install to home-level platform config directories instead of the current project.            |
-| `--target <platforms>` | Only install the listed platforms.                                                           |
-| `-y`, `--yes`          | Skip overwrite confirmation prompts and fail fast for missing presets.                       |
-| `--backup`             | Copy existing platform dirs/configs before writing.                                          |
-| `--runner <name>`      | Package runner for preset `extensions.yaml` entries. `npx` or `bunx`; default: auto-detect.  |
-| `--no-extensions`      | Skip preset `extensions.yaml` entries. Preset `skills.yaml` entries still run when declared. |
+| Flag                     | Effect                                                                                       |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| `-g`, `--global`         | Install to home-level platform config directories instead of the current project.            |
+| `--target <platforms>`   | Only install the listed platforms.                                                           |
+| `-y`, `--yes`            | Skip overwrite confirmation prompts and fail fast for missing presets.                       |
+| `--backup`               | Copy existing platform dirs/configs before writing.                                          |
+| `--runner <npx\|bunx>`   | Package runner for preset `extensions.yaml` entries. `npx` or `bunx`; default: auto-detect.  |
+| `--skip-extensions`      | Skip preset `extensions.yaml` entries. Preset `skills.yaml` entries still run when declared. |
+| `--skip-external-skills` | Skip installing external skills from preset `skills.yaml` entries.                           |
 
 ---
 
@@ -187,7 +189,7 @@ ulis build --source ./example
 Reinstall from an existing build without regenerating:
 
 ```bash
-ulis install --no-rebuild --yes
+ulis install --skip-rebuild --yes
 ```
 
 Build with reusable presets:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nejcm/ulis",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "ULIS - Unified LLM Interface Specification CLI. Generate agent/skill/mcp/rules configs for Claude Code, Codex, Cursor, OpenCode, and ForgeCode from a single source of truth.",
   "license": "ISC",
   "author": "nejcm",

--- a/skills/ulis/SKILL.md
+++ b/skills/ulis/SKILL.md
@@ -41,7 +41,7 @@ Help with `ulis` usage, not general coding.
 2. Give the narrowest command that matches that goal.
 3. State important side effects:
    - `build` writes only to `<source>/generated/<platform>/`
-   - `install` rebuilds unless `--no-rebuild` is used
+   - `install` rebuilds unless `--skip-rebuild` is used
    - project mode writes into the current project; global mode writes into the home directory
 4. If the user is unsure which files to edit, point them to `.ulis/agents/`, `.ulis/skills/`, `mcp.yaml`, `skills.yaml`, `permissions.yaml`, and `raw/`.
 

--- a/skills/ulis/references/cli-tui.md
+++ b/skills/ulis/references/cli-tui.md
@@ -14,7 +14,7 @@ Use this reference when the user needs concrete `ulis` commands or behavior deta
   - Does not install into platform config directories.
 - `ulis install`
   - Runs `build` first, then deploys generated files into platform directories.
-- `ulis install --no-rebuild`
+- `ulis install --skip-rebuild`
   - Reuses existing generated output.
 - `ulis preset list`
   - Lists user and bundled presets.
@@ -57,7 +57,7 @@ There is no walk-up search.
 - Install global config with backups:
   - `ulis install --global --backup --yes`
 - Reuse a previous build:
-  - `ulis install --no-rebuild --yes`
+  - `ulis install --skip-rebuild --yes`
 - Layer presets:
   - `ulis build --preset react-web,backend`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,26 +44,28 @@ async function main(): Promise<void> {
 
   cli
     .command("install", "Build configs from the ulis source tree and install them")
-    .option("-g, --global", "Read ~/.ulis/ and install to ~/.claude/, ~/.codex/, ~/forge/, etc.")
+    .option("-g, --global", "Read ~/.ulis/ and install to ~/.claude/, ~/.codex/, ~/.forge/, etc.")
     .option("-y, --yes", "Skip confirmation prompts (useful for CI)")
     .option("--source <path>", "Override the ulis source directory")
-    .option("--target <platform>", "Only build/install the given platform(s) (comma-separated)")
-    .option("--no-rebuild", "Skip the build step and install existing generated output")
+    .option("--target <platforms>", "Only build/install the given platform(s) (comma-separated)")
+    .option("--skip-rebuild", "Skip the build step and install existing generated output")
     .option("--backup", "Back up existing platform dirs before overwriting")
     .option("--preset <names>", "Apply user-global or bundled preset(s) (comma-separated)")
-    .option("--runner <name>", "Package runner used for extension installs (npx | bunx)")
-    .option("--no-extensions", "Skip running entries from extensions.yaml")
+    .option("--runner <npx|bunx>", "Package runner used for extension installs (npx | bunx)")
+    .option("--skip-extensions", "Skip running entries from extensions.yaml")
+    .option("--skip-external-skills", "Skip installing external skills from skills.yaml")
     .action((options) =>
       installCmd({
         global: Boolean(options.global),
         yes: Boolean(options.yes),
         source: options.source,
         target: options.target,
-        rebuild: options.rebuild !== false,
+        rebuild: !options.skipRebuild,
         backup: Boolean(options.backup),
         preset: options.preset,
         runner: parseRunner(options.runner),
-        extensions: options.extensions !== false,
+        extensions: !options.skipExtensions,
+        skipExternalSkills: Boolean(options.skipExternalSkills),
       }),
     );
 
@@ -71,7 +73,7 @@ async function main(): Promise<void> {
     .command("build", "Build configs into <source>/generated/ without installing")
     .option("-g, --global", "Build from ~/.ulis/")
     .option("--source <path>", "Override the ulis source directory")
-    .option("--target <platform>", "Only build the given platform(s) (comma-separated)")
+    .option("--target <platforms>", "Only build the given platform(s) (comma-separated)")
     .option("--preset <names>", "Apply user-global or bundled preset(s) (comma-separated)")
     .action((options) =>
       buildCmd({
@@ -85,12 +87,13 @@ async function main(): Promise<void> {
   cli
     .command("preset [...args]", "Manage presets (actions: list, install)")
     .option("-l, --list", "List user-global and bundled presets")
-    .option("-g, --global", "Install presets to ~/.claude/, ~/.codex/, ~/forge/, etc.")
+    .option("-g, --global", "Install presets to ~/.claude/, ~/.codex/, ~/.forge/, etc.")
     .option("-y, --yes", "Skip preset install confirmation prompts (useful for CI)")
-    .option("--target <platform>", "Only install the given platform(s) for preset install (comma-separated)")
+    .option("--target <platforms>", "Only install the given platform(s) for preset install (comma-separated)")
     .option("--backup", "Back up existing platform dirs before preset install")
-    .option("--runner <name>", "Package runner used for preset extension installs (npx | bunx)")
-    .option("--no-extensions", "Skip running entries from preset extensions.yaml")
+    .option("--runner <npx|bunx>", "Package runner used for preset extension installs (npx | bunx)")
+    .option("--skip-extensions", "Skip running entries from preset extensions.yaml")
+    .option("--skip-external-skills", "Skip installing external skills from preset skills.yaml")
     .action((args: string[] | undefined, options) => {
       const [action, ...names] = args ?? [];
       if (options.list || action == null || action === "list") return presetListCmd();
@@ -101,7 +104,8 @@ async function main(): Promise<void> {
           target: options.target,
           backup: Boolean(options.backup),
           runner: parseRunner(options.runner),
-          extensions: options.extensions !== false,
+          extensions: !options.skipExtensions,
+          skipExternalSkills: Boolean(options.skipExternalSkills),
         });
       }
       throw new Error(`Unknown preset action: "${action}". Available: list, install`);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -15,6 +15,7 @@ export interface InstallCmdOptions extends BuildCmdOptions {
   readonly rebuild?: boolean;
   readonly runner?: "npx" | "bunx";
   readonly extensions?: boolean;
+  readonly skipExternalSkills?: boolean;
 }
 
 /**
@@ -51,6 +52,7 @@ export async function installCmd(options: InstallCmdOptions = {}): Promise<void>
     presets,
     runner: options.runner,
     installExtensions: options.extensions ?? true,
+    installSkills: !options.skipExternalSkills,
   });
 }
 

--- a/src/commands/preset.ts
+++ b/src/commands/preset.ts
@@ -26,6 +26,7 @@ export interface PresetInstallCmdOptions {
   readonly backup?: boolean;
   readonly runner?: "npx" | "bunx";
   readonly extensions?: boolean;
+  readonly skipExternalSkills?: boolean;
   readonly presetsRoot?: string;
   readonly bundledPresetsRoot?: string;
   readonly userHome?: string;
@@ -90,6 +91,7 @@ export async function presetInstallCmd(
     presets,
     runner: options.runner,
     installExtensions: options.extensions ?? true,
+    installSkills: !options.skipExternalSkills,
     userHome,
   });
 }

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -559,6 +559,44 @@ describe("runInstall", () => {
     expect(skillsCommands[0]!.args).not.toContain("cursor");
   });
 
+  it("skips external skill installs when installSkills is false", async () => {
+    const root = createTempRoot();
+    const sourceDir = join(root, ".ulis");
+    const outputDir = join(sourceDir, "generated");
+    const projectDir = join(root, "project");
+    const userHome = join(root, "home");
+    mkdirSync(sourceDir, { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(userHome, { recursive: true });
+    write(join(outputDir, "codex", "AGENTS.md"), "Codex instructions.\n");
+    write(join(sourceDir, "skills.yaml"), ['"*":', "  skills:", "    - name: test/skill", ""].join("\n"));
+
+    const commands: Array<{ command: string; args: readonly string[] }> = [];
+    __test.setRuntimeDependencies({
+      runCommand(command, args) {
+        commands.push({ command, args });
+        return { status: 0, stdout: "", stderr: "" } as never;
+      },
+      async runAsyncCommand(command, args) {
+        commands.push({ command, args });
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    await runInstall({
+      sourceDir,
+      outputDir,
+      destBase: projectDir,
+      userHome,
+      platforms: ["codex"],
+      rebuild: false,
+      installSkills: false,
+      logger: silentLogger,
+    });
+
+    expect(commands.filter((command) => command.command === "npx")).toHaveLength(0);
+  });
+
   it("scopes wildcard skill installs to selected global platforms", async () => {
     const root = createTempRoot();
     const sourceDir = join(root, ".ulis");

--- a/src/install.ts
+++ b/src/install.ts
@@ -45,6 +45,8 @@ export interface InstallOptions {
   readonly runner?: InstallRunner;
   /** When false, skip running extensions installers (`extensions.yaml`). */
   readonly installExtensions?: boolean;
+  /** When false, skip installing external skills (`skills.yaml`). */
+  readonly installSkills?: boolean;
 }
 
 export interface PresetInstallOptions {
@@ -62,6 +64,8 @@ export interface PresetInstallOptions {
   readonly runner?: InstallRunner;
   /** When false, skip running extensions installers (`extensions.yaml`). */
   readonly installExtensions?: boolean;
+  /** When false, skip installing external skills (`skills.yaml`). */
+  readonly installSkills?: boolean;
   readonly signal?: AbortSignal;
 }
 
@@ -79,7 +83,8 @@ interface AsyncCommandResult {
 }
 
 type SkillInstallLog =
-  { readonly level: "success"; readonly message: string } | { readonly level: "warn"; readonly message: string };
+  | { readonly level: "success"; readonly message: string }
+  | { readonly level: "warn"; readonly message: string };
 
 type RunAsyncCommand = (
   command: string,
@@ -103,6 +108,7 @@ interface GeneratedInstallOptions {
   readonly extensionsConfig: ExtensionsConfig;
   readonly runner: InstallRunner;
   readonly installExtensionsEnabled: boolean;
+  readonly installSkillsEnabled: boolean;
   readonly logger: Logger;
   readonly signal?: AbortSignal;
 }
@@ -204,6 +210,7 @@ export async function runInstall(options: InstallOptions): Promise<readonly Plat
   ]);
 
   const installExtensionsEnabled = options.installExtensions ?? true;
+  const installSkillsEnabled = options.installSkills ?? true;
   const ulisConfig = loadValidatedConfigFile({
     dir: sourceDir,
     baseName: "config",
@@ -223,6 +230,7 @@ export async function runInstall(options: InstallOptions): Promise<readonly Plat
     extensionsConfig,
     runner,
     installExtensionsEnabled,
+    installSkillsEnabled,
     logger,
   });
 
@@ -246,6 +254,7 @@ export async function runPresetInstall(options: PresetInstallOptions): Promise<r
   const globalInstall = options.globalInstall ?? isSamePath(destBase, userHome);
   const backup = options.backup ?? false;
   const installExtensionsEnabled = options.installExtensions ?? true;
+  const installSkillsEnabled = options.installSkills ?? true;
   const runner = resolveRunner({ cliFlag: options.runner });
   const tempRoot = mkdtempSync(join(tmpdir(), "ulis-preset-install-"));
   const outputDir = join(tempRoot, ULIS_GENERATED_DIRNAME);
@@ -289,6 +298,7 @@ export async function runPresetInstall(options: PresetInstallOptions): Promise<r
       extensionsConfig,
       runner,
       installExtensionsEnabled,
+      installSkillsEnabled,
       logger,
       signal: options.signal,
     });
@@ -337,34 +347,36 @@ async function installGeneratedOutput(options: GeneratedInstallOptions): Promise
     }
   }
 
-  for (const platform of options.platforms) {
-    throwIfAborted(options.signal);
-    const platformSkills = options.skillsConfig[platform]?.skills ?? [];
-    if (platformSkills.length > 0) {
+  if (options.installSkillsEnabled) {
+    for (const platform of options.platforms) {
+      throwIfAborted(options.signal);
+      const platformSkills = options.skillsConfig[platform]?.skills ?? [];
+      if (platformSkills.length > 0) {
+        await installSkills(
+          platformSkills,
+          platform,
+          options.destBase,
+          options.globalInstall,
+          options.logger,
+          [],
+          options.signal,
+        );
+      }
+    }
+
+    const allSkills = options.skillsConfig["*"]?.skills ?? [];
+    if (allSkills.length > 0) {
+      logHeader(options.logger, "Installing External Skills");
       await installSkills(
-        platformSkills,
-        platform,
+        allSkills,
+        "*",
         options.destBase,
         options.globalInstall,
         options.logger,
-        [],
+        options.platforms,
         options.signal,
       );
     }
-  }
-
-  const allSkills = options.skillsConfig["*"]?.skills ?? [];
-  if (allSkills.length > 0) {
-    logHeader(options.logger, "Installing External Skills");
-    await installSkills(
-      allSkills,
-      "*",
-      options.destBase,
-      options.globalInstall,
-      options.logger,
-      options.platforms,
-      options.signal,
-    );
   }
 
   if (!options.installExtensionsEnabled) return;

--- a/src/tui/actions.test.ts
+++ b/src/tui/actions.test.ts
@@ -165,7 +165,7 @@ describe("tui actions child process flow", () => {
     expect(args).toContain("codex");
     expect(args).toContain("--yes");
     expect(args).toContain("--global");
-    expect(args).toContain("--no-rebuild");
+    expect(args).toContain("--skip-rebuild");
     expect(args).toContain("--backup");
   });
 

--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -78,6 +78,7 @@ export async function runTuiAction(
       logger,
       presets,
       installExtensions: state.presetInstallExtensions,
+      installSkills: !state.skipExternalSkills,
       signal: options.signal,
     });
     return;
@@ -120,8 +121,9 @@ async function runActionInChildProcess(
   if (action === "install") {
     args.push("--yes");
     if (planSource(state).globalInstall) args.push("--global");
-    if (!state.rebuild) args.push("--no-rebuild");
+    if (!state.rebuild) args.push("--skip-rebuild");
     if (state.backup) args.push("--backup");
+    if (state.skipExternalSkills) args.push("--skip-external-skills");
   }
 
   await new Promise<void>((resolve, reject) => {

--- a/src/tui/preferences.test.ts
+++ b/src/tui/preferences.test.ts
@@ -163,6 +163,7 @@ describe("tui preferences", () => {
           backup: false,
           rebuild: false,
           presetInstallExtensions: true,
+          skipExternalSkills: false,
         },
       },
     });

--- a/src/tui/preferences.ts
+++ b/src/tui/preferences.ts
@@ -194,6 +194,9 @@ function sanitizeFlowPreferences(raw: Record<string, unknown>): TuiFlowPreferenc
   if (typeof raw.presetInstallExtensions === "boolean") {
     next.presetInstallExtensions = raw.presetInstallExtensions;
   }
+  if (typeof raw.skipExternalSkills === "boolean") {
+    next.skipExternalSkills = raw.skipExternalSkills;
+  }
 
   return next;
 }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -135,15 +135,22 @@ function renderPlan(state: TuiState) {
     { text: `${presetLabel}: `, inlineValue: formatPresets(state) },
     state.flow === "presetsOnly"
       ? { text: "Base source: ", inlineValue: "none (preset-only install)" }
-      : { text: "Base source: ", inlineValue: `${formatSourceMode(state.sourceMode, state.customSource)} -> ${plan.sourceDir}` },
+      : {
+          text: "Base source: ",
+          inlineValue: `${formatSourceMode(state.sourceMode, state.customSource)} -> ${plan.sourceDir}`,
+        },
     { text: "" },
     { text: "Output", fgColor: "color06", bold: true },
     { text: "Platforms: ", inlineValue: formatPlatforms(state.platforms) },
-    { text: "Install destination: ", inlineValue: `${formatDestinationMode(state.destinationMode)} -> ${plan.destBase}` },
+    {
+      text: "Install destination: ",
+      inlineValue: `${formatDestinationMode(state.destinationMode)} -> ${plan.destBase}`,
+    },
     { text: "" },
     { text: "Install options", fgColor: "color06", bold: true },
     { text: "Backup: ", inlineValue: state.backup ? "on" : "off" },
     { text: "Use latest build output: ", inlineValue: state.rebuild ? "on" : "off" },
+    { text: "Skip external skills: ", inlineValue: state.skipExternalSkills ? "on" : "off" },
   ];
 
   return renderCardShell(
@@ -174,6 +181,7 @@ function planLabel(state: TuiState, label: TuiPlanItem): string {
   if (label === "Backup") return state.backup ? "on" : "off";
   if (label === "Use latest build output") return state.rebuild ? "on" : "off";
   if (label === "Run preset extensions") return state.presetInstallExtensions ? "on" : "off";
+  if (label === "Skip external skills") return state.skipExternalSkills ? "on" : "off";
   return label;
 }
 
@@ -250,10 +258,7 @@ function renderUiLine(line: UiLine): Node {
         alignItems: "start",
         justifyContent: "start",
       },
-      [
-        Text(line.text, { bold: line.bold, wrap: "word" }),
-        Text(line.inlineValue, { bold: true, wrap: "word" }),
-      ],
+      [Text(line.text, { bold: line.bold, wrap: "word" }), Text(line.inlineValue, { bold: true, wrap: "word" })],
     );
   }
   return line.value == null
@@ -533,8 +538,9 @@ function formatInstallCommand(state: TuiState): string {
   const args = ["ulis", "install", "--source", plan.sourceDir, "--target", state.platforms.join(","), "--yes"];
   if (state.destinationMode === "global") args.push("--global");
   if (state.selectedPresetNames.length > 0) args.push("--preset", state.selectedPresetNames.join(","));
-  if (!state.rebuild) args.push("--no-rebuild");
+  if (!state.rebuild) args.push("--skip-rebuild");
   if (state.backup) args.push("--backup");
+  if (state.skipExternalSkills) args.push("--skip-external-skills");
   return args.map(quoteCommandArg).join(" ");
 }
 

--- a/src/tui/state.test.ts
+++ b/src/tui/state.test.ts
@@ -84,7 +84,7 @@ describe("tui state", () => {
     try {
       const state = createInitialState();
       state.screen = "plan";
-      state.cursor = 6;
+      state.cursor = 7;
 
       expect(handleTuiKey(state, "enter")).toEqual({ type: "start", action: "validate" });
     } finally {
@@ -100,7 +100,7 @@ describe("tui state", () => {
     try {
       const state = createInitialState();
       state.screen = "plan";
-      state.cursor = 8;
+      state.cursor = 9;
 
       expect(handleTuiKey(state, "enter")).toEqual({ type: "none" });
       expect(state.screen as string).toBe("installReview");
@@ -116,7 +116,7 @@ describe("tui state", () => {
     try {
       const state = createInitialState();
       state.screen = "plan";
-      state.cursor = 7;
+      state.cursor = 8;
 
       expect(handleTuiKey(state, "enter")).toEqual({ type: "none" });
       expect(state.screen as string).toBe("missingSource");
@@ -199,11 +199,11 @@ describe("tui state", () => {
     Date.now = () => now;
 
     try {
-      state.cursor = 5;
+      state.cursor = 6;
       expect(handleTuiKey(state, "enter")).toEqual({ type: "start", action: "presetValidate" });
 
       now += 45;
-      state.cursor = 6;
+      state.cursor = 7;
       expect(handleTuiKey(state, "enter")).toEqual({ type: "none" });
       expect(state.screen as string).toBe("presetInstallReview");
     } finally {

--- a/src/tui/state.ts
+++ b/src/tui/state.ts
@@ -35,6 +35,7 @@ export type TuiPlanItem =
   | "Backup"
   | "Use latest build output"
   | "Run preset extensions"
+  | "Skip external skills"
   | "Validate"
   | "Build only"
   | "Install"
@@ -59,6 +60,7 @@ export interface TuiFlowPreferences {
   readonly backup?: boolean;
   readonly rebuild?: boolean;
   readonly presetInstallExtensions?: boolean;
+  readonly skipExternalSkills?: boolean;
 }
 
 export interface TuiState {
@@ -78,6 +80,7 @@ export interface TuiState {
   backup: boolean;
   rebuild: boolean;
   presetInstallExtensions: boolean;
+  skipExternalSkills: boolean;
   flowPreferences: Partial<Record<TuiPreferenceScope, TuiFlowPreferences>>;
   logs: string[];
   notice: string;
@@ -110,6 +113,7 @@ export const DASHBOARD_ITEMS: readonly TuiPlanItem[] = [
   "Install destination",
   "Backup",
   "Use latest build output",
+  "Skip external skills",
   "Validate",
   "Build only",
   "Install",
@@ -122,6 +126,7 @@ const PRESET_ONLY_PLAN_ITEMS: readonly TuiPlanItem[] = [
   "Install destination",
   "Backup",
   "Run preset extensions",
+  "Skip external skills",
   "Validate",
   "Install",
   "Back to start",
@@ -154,6 +159,7 @@ export function createInitialState(availablePresets: readonly PresetListEntry[] 
     backup: true,
     rebuild: true,
     presetInstallExtensions: true,
+    skipExternalSkills: false,
     flowPreferences: {},
     logs: [],
     notice: "",
@@ -356,6 +362,7 @@ export function flowPreferencesFromState(state: TuiState): TuiFlowPreferences {
     backup: state.backup,
     rebuild: state.rebuild,
     presetInstallExtensions: state.presetInstallExtensions,
+    skipExternalSkills: state.skipExternalSkills,
   };
 
   if (state.flow === "custom" && state.customSource) preferences.customSource = state.customSource;
@@ -404,6 +411,9 @@ export function applyFlowPreferences(state: TuiState, flow: TuiFlow = state.flow
   if (typeof preferences.rebuild === "boolean") state.rebuild = preferences.rebuild;
   if (typeof preferences.presetInstallExtensions === "boolean") {
     state.presetInstallExtensions = preferences.presetInstallExtensions;
+  }
+  if (typeof preferences.skipExternalSkills === "boolean") {
+    state.skipExternalSkills = preferences.skipExternalSkills;
   }
 }
 
@@ -547,6 +557,12 @@ function handlePlanKey(state: TuiState, key: string): TuiEffect {
     return { type: "none" };
   }
 
+  if (item === "Skip external skills" && isToggleKey(key)) {
+    state.skipExternalSkills = !state.skipExternalSkills;
+    state.notice = "";
+    return { type: "none" };
+  }
+
   if (item === "Install destination" && isToggleKey(key)) {
     state.destinationMode = state.destinationMode === "global" ? "project" : "global";
     state.notice = "";
@@ -581,6 +597,9 @@ function handlePlanKey(state: TuiState, key: string): TuiEffect {
       break;
     case "Run preset extensions":
       state.presetInstallExtensions = !state.presetInstallExtensions;
+      break;
+    case "Skip external skills":
+      state.skipExternalSkills = !state.skipExternalSkills;
       break;
     case "Validate":
       if (state.flow === "presetsOnly") return startPresetOnlyAction(state, "presetValidate");


### PR DESCRIPTION
Adds a CLI/TUI option to skip installing external skills declared in skills.yaml. Also renames --no-rebuild/--no-extensions to --skip-rebuild/--skip-extensions so all disable flags share one --skip-* convention, and fixes --target/--runner placeholders plus a ~/.forge/ typo in help text.