### PR TITLE
chore(release): add --skip-external-skills flag and standardize CLI flag naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,18 @@ In CI or other non-interactive runs, add `--yes` so a missing preset name fails 
 
 ### Common flags
 
-| Flag                  | Applies to         | Description                                                                  |
-| --------------------- | ------------------ | ---------------------------------------------------------------------------- |
-| `-g`, `--global`      | all                | Operate on `~/.ulis/` and home-level install targets (`~/.claude/`…)         |
-| `--source <path>`     | `build`, `install` | Override the source directory; with `--global`, installs still target home   |
-| `--target <platform>` | `build`, `install` | Comma-separated list: `claude`, `codex`, `cursor`, `opencode`, `forgecode`   |
-| `--preset <names>`    | `build`, `install` | Apply preset(s) from `~/.ulis/presets/` or bundled presets (comma-separated) |
-| `-y`, `--yes`         | `install`          | Skip confirmation prompts                                                    |
-| `--no-rebuild`        | `install`          | Skip the build step and deploy existing `generated/`                         |
-| `--backup`            | `install`          | Back up existing platform dirs (`<dir>.backup.YYYYMMDD_HHMMSS`)              |
-| `--runner <name>`     | `install`          | Package runner for `extensions.yaml` (`npx` or `bunx`)                       |
-| `--no-extensions`     | `install`          | Skip running entries from `extensions.yaml`                                  |
+| Flag                     | Applies to         | Description                                                                  |
+| ------------------------ | ------------------ | ---------------------------------------------------------------------------- |
+| `-g`, `--global`         | all                | Operate on `~/.ulis/` and home-level install targets (`~/.claude/`…)         |
+| `--source <path>`        | `build`, `install` | Override the source directory; with `--global`, installs still target home   |
+| `--target <platforms>`   | `build`, `install` | Comma-separated list: `claude`, `codex`, `cursor`, `opencode`, `forgecode`   |
+| `--preset <names>`       | `build`, `install` | Apply preset(s) from `~/.ulis/presets/` or bundled presets (comma-separated) |
+| `-y`, `--yes`            | `install`          | Skip confirmation prompts                                                    |
+| `--skip-rebuild`         | `install`          | Skip the build step and deploy existing `generated/`                         |
+| `--backup`               | `install`          | Back up existing platform dirs (`<dir>.backup.YYYYMMDD_HHMMSS`)              |
+| `--runner <npx\|bunx>`   | `install`          | Package runner for `extensions.yaml` (`npx` or `bunx`)                       |
+| `--skip-extensions`      | `install`          | Skip running entries from `extensions.yaml`                                  |
+| `--skip-external-skills` | `install`          | Skip installing external skills declared in `skills.yaml`                    |
 
 ### Presets (quick reference)
 
@@ -265,7 +266,7 @@ claude:
 2. `runner: npx | bunx` in `config.yaml`
 3. Auto-detect: `bunx` if available on PATH, otherwise `npx`
 
-A single failing extension logs a warning and the install continues. Skip the phase entirely with `--no-extensions`. Extensions are always re-run on each install (no caching in this version — see [SPEC.md](docs/SPEC.md) for the future caching plan).
+A single failing extension logs a warning and the install continues. Skip the phase entirely with `--skip-extensions`. Extensions are always re-run on each install (no caching in this version — see [SPEC.md](docs/SPEC.md) for the future caching plan).
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@nejcm/ai-config-build",
       "dependencies": {
         "@cel-tui/core": "~0.8.3",
+        "@decimalturn/toml-patch": "~2.1.0",
         "cac": "~7.0.0",
         "gray-matter": "~4.0.3",
         "smol-toml": "~1.6.1",
@@ -75,6 +76,8 @@
     "@cel-tui/core": ["@cel-tui/core@0.8.3", "", { "dependencies": { "@cel-tui/types": "0.8.3", "get-east-asian-width": "^1.5.0" }, "peerDependencies": { "typescript": ">=5.0.0" } }, "sha512-rC6nqza70HTvJGoY5cm86nwBMRnfim3g4Ysns+HebYkjwXv4a0VIcLmRNQFATNq4R/Xtg7+ba/qzsqJvTY22IA=="],
 
     "@cel-tui/types": ["@cel-tui/types@0.8.3", "", { "peerDependencies": { "typescript": ">=5.0.0" } }, "sha512-yEKXCY16U/W4A4JaVysv2/x/IBEHQAfb93CzL6HugN+N15ETB3Vn8tZrQwdyrOT/9WdlCQkeBH8Vj7BJHs4Hkw=="],
+
+    "@decimalturn/toml-patch": ["@decimalturn/toml-patch@2.1.0", "", {}, "sha512-IICXlX7hcD9lGN7k+vDXcVnOfcbOEqMpeQHRnrhnmm7tZ8HluFrSgBKLNC72fQpNXynbJTC7pjtfNCaKrKlGyA=="],
 
     "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,21 +72,22 @@ Run `build` and then deploy the generated configs onto the target platform direc
 
 ```bash
 ulis install [-g | --global] [--source <path>] [--target <platforms>]
-             [-y | --yes] [--no-rebuild] [--backup] [--preset <names>]
-             [--runner <npx|bunx>] [--no-extensions]
+             [-y | --yes] [--skip-rebuild] [--backup] [--preset <names>]
+             [--runner <npx|bunx>] [--skip-extensions] [--skip-external-skills]
 ```
 
-| Flag                   | Effect                                                                                                                                                     |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-g`, `--global`       | Read `~/.ulis/` and write to `~/.claude/`, `~/.codex/`, `~/.cursor/`, `~/.config/opencode/` (Windows: `%USERPROFILE%\.config\opencode\`), and `~/.forge/`. |
-| `--source <path>`      | Override source (still writes to CWD or home depending on `--global`).                                                                                     |
-| `--target <platforms>` | Only build/install the listed platforms.                                                                                                                   |
-| `-y`, `--yes`          | Skip the "about to overwrite" confirmation prompt.                                                                                                         |
-| `--no-rebuild`         | Don't rebuild — install whatever is already under `<source>/generated/`.                                                                                   |
-| `--backup`             | Copy each existing platform dir to `<dir>.backup.YYYYMMDD_HHMMSS` before writing.                                                                          |
-| `--preset <names>`     | Same resolution as `ulis build --preset` (user-global directory, then bundled).                                                                            |
-| `--runner <name>`      | Package runner used for `extensions.yaml` entries. `npx` or `bunx`. Overrides `runner` in `config.yaml`. Default: auto-detect (`bunx` if present).         |
-| `--no-extensions`      | Skip running entries from `extensions.yaml`. Useful in CI where network installs are not desired.                                                          |
+| Flag                     | Effect                                                                                                                                                     |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-g`, `--global`         | Read `~/.ulis/` and write to `~/.claude/`, `~/.codex/`, `~/.cursor/`, `~/.config/opencode/` (Windows: `%USERPROFILE%\.config\opencode\`), and `~/.forge/`. |
+| `--source <path>`        | Override source (still writes to CWD or home depending on `--global`).                                                                                     |
+| `--target <platforms>`   | Only build/install the listed platforms.                                                                                                                   |
+| `-y`, `--yes`            | Skip the "about to overwrite" confirmation prompt.                                                                                                         |
+| `--skip-rebuild`         | Don't rebuild — install whatever is already under `<source>/generated/`.                                                                                   |
+| `--backup`               | Copy each existing platform dir to `<dir>.backup.YYYYMMDD_HHMMSS` before writing.                                                                          |
+| `--preset <names>`       | Same resolution as `ulis build --preset` (user-global directory, then bundled).                                                                            |
+| `--runner <npx\|bunx>`   | Package runner used for `extensions.yaml` entries. `npx` or `bunx`. Overrides `runner` in `config.yaml`. Default: auto-detect (`bunx` if present).         |
+| `--skip-extensions`      | Skip running entries from `extensions.yaml`. Useful in CI where network installs are not desired.                                                          |
+| `--skip-external-skills` | Skip installing external skills declared in `skills.yaml`. Useful in CI where network installs are not desired.                                            |
 
 **Preset resolution:** Each name maps to a directory. ULIS checks `~/.ulis/presets/<name>/` first; if that folder is missing, it uses the matching bundled preset next to the CLI (`dist/presets/` when installed). A preset in your home tree with the same folder name **shadows** the bundled one. Multiple `--preset` values merge **left to right**, then the base source (from `--source`, `./.ulis/`, or `~/.ulis/`) is applied last — **the base wins on conflicts**. Interactive runs prompt to continue when a name is missing; with `--yes`, missing presets fail immediately.
 
@@ -133,21 +134,22 @@ ulis preset [--list]
 ulis preset list
 ulis preset install <names...> [-g | --global] [--target <platforms>]
                     [-y | --yes] [--backup] [--runner <npx|bunx>]
-                    [--no-extensions]
+                    [--skip-extensions] [--skip-external-skills]
 ```
 
 `-l` / `--list` is accepted. The default action is `list`. Each line shows the directory name (what you pass to `--preset`), a `user` or `bundled` label, optional `name` / `description` from `preset.yaml`, and the display title when it differs from the folder name.
 
 `ulis preset install <names...>` installs selected presets **without** merging a project or global source. Names may be comma-separated (`a,b`) or repeated (`a b`) and are merged in the order given. Generated output is temporary and is removed after install.
 
-| Flag                   | Effect                                                                                       |
-| ---------------------- | -------------------------------------------------------------------------------------------- |
-| `-g`, `--global`       | Install to home-level platform config directories instead of the current project.            |
-| `--target <platforms>` | Only install the listed platforms.                                                           |
-| `-y`, `--yes`          | Skip overwrite confirmation prompts and fail fast for missing presets.                       |
-| `--backup`             | Copy existing platform dirs/configs before writing.                                          |
-| `--runner <name>`      | Package runner for preset `extensions.yaml` entries. `npx` or `bunx`; default: auto-detect.  |
-| `--no-extensions`      | Skip preset `extensions.yaml` entries. Preset `skills.yaml` entries still run when declared. |
+| Flag                     | Effect                                                                                       |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| `-g`, `--global`         | Install to home-level platform config directories instead of the current project.            |
+| `--target <platforms>`   | Only install the listed platforms.                                                           |
+| `-y`, `--yes`            | Skip overwrite confirmation prompts and fail fast for missing presets.                       |
+| `--backup`               | Copy existing platform dirs/configs before writing.                                          |
+| `--runner <npx\|bunx>`   | Package runner for preset `extensions.yaml` entries. `npx` or `bunx`; default: auto-detect.  |
+| `--skip-extensions`      | Skip preset `extensions.yaml` entries. Preset `skills.yaml` entries still run when declared. |
+| `--skip-external-skills` | Skip installing external skills from preset `skills.yaml` entries.                           |
 
 ---
 
@@ -187,7 +189,7 @@ ulis build --source ./example
 Reinstall from an existing build without regenerating:
 
 ```bash
-ulis install --no-rebuild --yes
+ulis install --skip-rebuild --yes
 ```
 
 Build with reusable presets:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -93,15 +93,15 @@ ulis install [-g | --global] [--source <path>] [--target <platforms>]
 
 **Install strategy per platform:**
 
-| Platform  | Managed entries                                                              | Preserved native config                                                       |
-| --------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Claude    | generated `agents/` and `skills/` entries by name; `commands/`, `rules/`, …  | `settings.json` `hooks`, UI/plugin settings; `.claude.json` `mcpServers`      |
-| OpenCode  | generated `agents/core`, `agents/specialized`, and `skills/` entries by name | `opencode.json` `mcp`                                                         |
-| Codex     | generated `agents/` and `skills/` entries by name                            | `config.toml` `projects`, `hooks`, `mcp_servers`, `tui`, `notice`, `features` |
-| Cursor    | generated `agents/` and `skills/` entries by name                            | `mcp.json` `mcpServers`                                                       |
-| ForgeCode | generated `.forge/agents` and `.forge/skills` entries by name; `AGENTS.md`   | `.forge/.mcp.json` `mcpServers`, `.forge.toml`                                |
+| Platform  | Managed entries                                                              | Preserved native config                                                                |
+| --------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Claude    | generated `agents/` and `skills/` entries by name; `commands/`, `rules/`, …  | all `settings.json` and global `.claude.json` values; project `.mcp.json` `mcpServers` |
+| OpenCode  | generated `agents/core`, `agents/specialized`, and `skills/` entries by name | `opencode.json` `mcp`                                                                  |
+| Codex     | generated `agents/` and `skills/` entries by name                            | all `config.toml` values; unrelated comments and order                                 |
+| Cursor    | generated `agents/` and `skills/` entries by name                            | `mcp.json` `mcpServers`                                                                |
+| ForgeCode | generated `.forge/agents` and `.forge/skills` entries by name; `AGENTS.md`   | `.forge/.mcp.json` `mcpServers`, `.forge.toml`                                         |
 
-Install preserves unmanaged destination agents and skills unless generated output has the same native name. Generated output wins at the same config path, and raw fragments win through the generated output because raw is merged during build. Existing non-allowlisted native config values are removed. If `--backup` is set, backups are created before parsing preserved native config.
+Install preserves unmanaged destination agents and skills unless generated output has the same native name. For Codex `config.toml`, Claude `settings.json`, and global `.claude.json`, the existing file is the base: generated values overwrite only matching paths, while absent values remain. Other native configs retain their allowlisted preservation rules. Raw fragments win through the generated output because raw is merged during build. If `--backup` is set, backups are created before parsing preserved native config.
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -25,7 +25,7 @@ ULIS is a CLI (`ulis`) that lets you define AI agent configurations **once** and
 └── config.yaml          ◄─── version + name + optional install + runner settings
 ```
 
-`ulis install` deploys the generated tree to the per-platform destination (`./.claude/`, `./.forge/`, etc.). Existing unmanaged destination agents and skills are left in place unless a generated entry has the same native name. Install also preserves allowlisted existing native config values or files such as MCP servers, hooks, trusted projects, selected Claude Code preferences, Codex `tui`, `notice`, and `features`, and ForgeCode `.forge.toml`.
+`ulis install` deploys the generated tree to the per-platform destination (`./.claude/`, `./.forge/`, etc.). Existing unmanaged destination agents and skills are left in place unless a generated entry has the same native name. Codex `config.toml`, Claude `settings.json`, and global `.claude.json` use base-first overlays: generated values overwrite matching paths and absent native values remain. Codex TOML comments and ordering outside generated paths are preserved. Other native configs preserve their allowlisted values or files, such as MCP server maps and ForgeCode `.forge.toml`.
 
 **Why it exists:** Claude Code, OpenCode, Codex, Cursor, and ForgeCode all have incompatible config formats. Without ULIS you maintain separate, drift-prone config trees. ULIS keeps one source of truth and compiles it.
 

--- a/docs/adr/0001-preserve-native-config-only.md
+++ b/docs/adr/0001-preserve-native-config-only.md
@@ -1,3 +1,5 @@
-# Preserve Native Config Only
+# Preserve Native Config by Ownership
 
-ULIS install preserves only allowlisted destination-native config values or files, such as MCP server maps, hooks, Claude Code UI/plugin settings, Codex trusted projects, selected Codex preferences like `tui`, `notice`, and `features`, and ForgeCode `.forge.toml`. Existing model defaults, permission settings, and other native preferences are not preserved because ULIS cannot reliably distinguish user intent from stale generated output; raw fragments remain the explicit escape hatch and win at the same config path.
+ULIS uses base-first overlays for Codex `config.toml`, Claude `settings.json`, and global `.claude.json`. The existing native file is the base, current generated values overwrite matching leaf paths, and values absent from the generated config remain. This intentionally keeps both user-owned values and stale values because ULIS does not maintain an ownership manifest. Codex TOML is patched in place so unrelated comments, formatting, and ordering survive.
+
+Project `.mcp.json` and other destination-native configs keep their existing allowlisted preservation rules. Raw fragments remain the explicit override and win at the same config path because they are merged into generated output before install.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@cel-tui/core": "~0.8.3",
+    "@decimalturn/toml-patch": "~2.1.0",
     "cac": "~7.0.0",
     "gray-matter": "~4.0.3",
     "smol-toml": "~1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nejcm/ulis",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "ULIS - Unified LLM Interface Specification CLI. Generate agent/skill/mcp/rules configs for Claude Code, Codex, Cursor, OpenCode, and ForgeCode from a single source of truth.",
   "license": "ISC",
   "author": "nejcm",

--- a/skills/ulis/SKILL.md
+++ b/skills/ulis/SKILL.md
@@ -41,7 +41,7 @@ Help with `ulis` usage, not general coding.
 2. Give the narrowest command that matches that goal.
 3. State important side effects:
    - `build` writes only to `<source>/generated/<platform>/`
-   - `install` rebuilds unless `--no-rebuild` is used
+   - `install` rebuilds unless `--skip-rebuild` is used
    - project mode writes into the current project; global mode writes into the home directory
 4. If the user is unsure which files to edit, point them to `.ulis/agents/`, `.ulis/skills/`, `mcp.yaml`, `skills.yaml`, `permissions.yaml`, and `raw/`.
 

--- a/skills/ulis/references/cli-tui.md
+++ b/skills/ulis/references/cli-tui.md
@@ -14,7 +14,7 @@ Use this reference when the user needs concrete `ulis` commands or behavior deta
   - Does not install into platform config directories.
 - `ulis install`
   - Runs `build` first, then deploys generated files into platform directories.
-- `ulis install --no-rebuild`
+- `ulis install --skip-rebuild`
   - Reuses existing generated output.
 - `ulis preset list`
   - Lists user and bundled presets.
@@ -57,7 +57,7 @@ There is no walk-up search.
 - Install global config with backups:
   - `ulis install --global --backup --yes`
 - Reuse a previous build:
-  - `ulis install --no-rebuild --yes`
+  - `ulis install --skip-rebuild --yes`
 - Layer presets:
   - `ulis build --preset react-web,backend`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,26 +44,28 @@ async function main(): Promise<void> {
 
   cli
     .command("install", "Build configs from the ulis source tree and install them")
-    .option("-g, --global", "Read ~/.ulis/ and install to ~/.claude/, ~/.codex/, ~/forge/, etc.")
+    .option("-g, --global", "Read ~/.ulis/ and install to ~/.claude/, ~/.codex/, ~/.forge/, etc.")
     .option("-y, --yes", "Skip confirmation prompts (useful for CI)")
     .option("--source <path>", "Override the ulis source directory")
-    .option("--target <platform>", "Only build/install the given platform(s) (comma-separated)")
-    .option("--no-rebuild", "Skip the build step and install existing generated output")
+    .option("--target <platforms>", "Only build/install the given platform(s) (comma-separated)")
+    .option("--skip-rebuild", "Skip the build step and install existing generated output")
     .option("--backup", "Back up existing platform dirs before overwriting")
     .option("--preset <names>", "Apply user-global or bundled preset(s) (comma-separated)")
-    .option("--runner <name>", "Package runner used for extension installs (npx | bunx)")
-    .option("--no-extensions", "Skip running entries from extensions.yaml")
+    .option("--runner <npx|bunx>", "Package runner used for extension installs (npx | bunx)")
+    .option("--skip-extensions", "Skip running entries from extensions.yaml")
+    .option("--skip-external-skills", "Skip installing external skills from skills.yaml")
     .action((options) =>
       installCmd({
         global: Boolean(options.global),
         yes: Boolean(options.yes),
         source: options.source,
         target: options.target,
-        rebuild: options.rebuild !== false,
+        rebuild: !options.skipRebuild,
         backup: Boolean(options.backup),
         preset: options.preset,
         runner: parseRunner(options.runner),
-        extensions: options.extensions !== false,
+        extensions: !options.skipExtensions,
+        skipExternalSkills: Boolean(options.skipExternalSkills),
       }),
     );
 
@@ -71,7 +73,7 @@ async function main(): Promise<void> {
     .command("build", "Build configs into <source>/generated/ without installing")
     .option("-g, --global", "Build from ~/.ulis/")
     .option("--source <path>", "Override the ulis source directory")
-    .option("--target <platform>", "Only build the given platform(s) (comma-separated)")
+    .option("--target <platforms>", "Only build the given platform(s) (comma-separated)")
     .option("--preset <names>", "Apply user-global or bundled preset(s) (comma-separated)")
     .action((options) =>
       buildCmd({
@@ -85,12 +87,13 @@ async function main(): Promise<void> {
   cli
     .command("preset [...args]", "Manage presets (actions: list, install)")
     .option("-l, --list", "List user-global and bundled presets")
-    .option("-g, --global", "Install presets to ~/.claude/, ~/.codex/, ~/forge/, etc.")
+    .option("-g, --global", "Install presets to ~/.claude/, ~/.codex/, ~/.forge/, etc.")
     .option("-y, --yes", "Skip preset install confirmation prompts (useful for CI)")
-    .option("--target <platform>", "Only install the given platform(s) for preset install (comma-separated)")
+    .option("--target <platforms>", "Only install the given platform(s) for preset install (comma-separated)")
     .option("--backup", "Back up existing platform dirs before preset install")
-    .option("--runner <name>", "Package runner used for preset extension installs (npx | bunx)")
-    .option("--no-extensions", "Skip running entries from preset extensions.yaml")
+    .option("--runner <npx|bunx>", "Package runner used for preset extension installs (npx | bunx)")
+    .option("--skip-extensions", "Skip running entries from preset extensions.yaml")
+    .option("--skip-external-skills", "Skip installing external skills from preset skills.yaml")
     .action((args: string[] | undefined, options) => {
       const [action, ...names] = args ?? [];
       if (options.list || action == null || action === "list") return presetListCmd();
@@ -101,7 +104,8 @@ async function main(): Promise<void> {
           target: options.target,
           backup: Boolean(options.backup),
           runner: parseRunner(options.runner),
-          extensions: options.extensions !== false,
+          extensions: !options.skipExtensions,
+          skipExternalSkills: Boolean(options.skipExternalSkills),
         });
       }
       throw new Error(`Unknown preset action: "${action}". Available: list, install`);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -15,6 +15,7 @@ export interface InstallCmdOptions extends BuildCmdOptions {
   readonly rebuild?: boolean;
   readonly runner?: "npx" | "bunx";
   readonly extensions?: boolean;
+  readonly skipExternalSkills?: boolean;
 }
 
 /**
@@ -51,6 +52,7 @@ export async function installCmd(options: InstallCmdOptions = {}): Promise<void>
     presets,
     runner: options.runner,
     installExtensions: options.extensions ?? true,
+    installSkills: !options.skipExternalSkills,
   });
 }
 

--- a/src/commands/preset.ts
+++ b/src/commands/preset.ts
@@ -26,6 +26,7 @@ export interface PresetInstallCmdOptions {
   readonly backup?: boolean;
   readonly runner?: "npx" | "bunx";
   readonly extensions?: boolean;
+  readonly skipExternalSkills?: boolean;
   readonly presetsRoot?: string;
   readonly bundledPresetsRoot?: string;
   readonly userHome?: string;
@@ -90,6 +91,7 @@ export async function presetInstallCmd(
     presets,
     runner: options.runner,
     installExtensions: options.extensions ?? true,
+    installSkills: !options.skipExternalSkills,
     userHome,
   });
 }

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -559,6 +559,44 @@ describe("runInstall", () => {
     expect(skillsCommands[0]!.args).not.toContain("cursor");
   });
 
+  it("skips external skill installs when installSkills is false", async () => {
+    const root = createTempRoot();
+    const sourceDir = join(root, ".ulis");
+    const outputDir = join(sourceDir, "generated");
+    const projectDir = join(root, "project");
+    const userHome = join(root, "home");
+    mkdirSync(sourceDir, { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(userHome, { recursive: true });
+    write(join(outputDir, "codex", "AGENTS.md"), "Codex instructions.\n");
+    write(join(sourceDir, "skills.yaml"), ['"*":', "  skills:", "    - name: test/skill", ""].join("\n"));
+
+    const commands: Array<{ command: string; args: readonly string[] }> = [];
+    __test.setRuntimeDependencies({
+      runCommand(command, args) {
+        commands.push({ command, args });
+        return { status: 0, stdout: "", stderr: "" } as never;
+      },
+      async runAsyncCommand(command, args) {
+        commands.push({ command, args });
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    await runInstall({
+      sourceDir,
+      outputDir,
+      destBase: projectDir,
+      userHome,
+      platforms: ["codex"],
+      rebuild: false,
+      installSkills: false,
+      logger: silentLogger,
+    });
+
+    expect(commands.filter((command) => command.command === "npx")).toHaveLength(0);
+  });
+
   it("scopes wildcard skill installs to selected global platforms", async () => {
     const root = createTempRoot();
     const sourceDir = join(root, ".ulis");

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -54,7 +54,7 @@ afterEach(() => {
 });
 
 describe("runInstall", () => {
-  it("preserves allowlisted Codex config sections for project installs", async () => {
+  it("overlays generated Codex values while preserving unmanaged config for project installs", async () => {
     const root = createTempRoot();
     const sourceDir = join(root, ".ulis");
     const outputDir = join(sourceDir, "generated");
@@ -127,6 +127,7 @@ describe("runInstall", () => {
     });
 
     expect(readMergeableConfig(join(projectDir, ".codex", "config.toml"))).toEqual({
+      model: "old",
       approval_policy: "never",
       notice: "generated",
       hooks: { pre: ["raw"] },
@@ -144,7 +145,7 @@ describe("runInstall", () => {
     });
   });
 
-  it("preserves allowlisted Codex config sections for global installs", async () => {
+  it("overlays generated Codex values while preserving unmanaged config for global installs", async () => {
     const root = createTempRoot();
     const sourceDir = join(root, ".ulis");
     const outputDir = join(sourceDir, "generated");
@@ -180,6 +181,7 @@ describe("runInstall", () => {
     });
 
     expect(readMergeableConfig(join(userHome, ".codex", "config.toml"))).toEqual({
+      model: "old",
       approval_policy: "on-request",
       notice: "existing",
       features: { responses: true },
@@ -188,7 +190,183 @@ describe("runInstall", () => {
     });
   });
 
-  it("preserves allowlisted native config across platform installs", async () => {
+  it("preserves Codex comments, formatting, and order outside generated paths", async () => {
+    const root = createTempRoot();
+    const sourceDir = join(root, ".ulis");
+    const outputDir = join(sourceDir, "generated");
+    const userHome = join(root, "home");
+    mkdirSync(sourceDir, { recursive: true });
+    mkdirSync(userHome, { recursive: true });
+
+    write(
+      join(outputDir, "codex", "config.toml"),
+      [
+        "[mcp_servers.generated]",
+        'command = "node"',
+        "",
+        "[mcp_servers.generated.env]",
+        'TOKEN = "generated"',
+        "",
+      ].join("\n"),
+    );
+    const existing = [
+      "# --- Headroom persistent provider ---",
+      'model_provider = "headroom"',
+      'openai_base_url = "http://127.0.0.1:8787/v1"',
+      "",
+      "notify = [",
+      '  "C:\\\\Users\\\\Nejc\\\\codex-computer-use.exe",',
+      '  "turn-ended",',
+      "]",
+      "matrix = [",
+      "  [1, 2],",
+      "  [3, 4],",
+      "]",
+      'message = """',
+      "[not.a.table]",
+      '"""',
+      "[model_providers.headroom]",
+      'name = "Headroom persistent proxy"',
+      'base_url = "http://127.0.0.1:8787/v1"',
+      "supports_websockets = true",
+      "requires_openai_auth = true",
+      "# --- end Headroom persistent provider ---",
+      "",
+    ].join("\r\n");
+    write(join(userHome, ".codex", "config.toml"), existing);
+
+    await runInstall({
+      sourceDir,
+      outputDir,
+      destBase: userHome,
+      userHome,
+      platforms: ["codex"],
+      rebuild: false,
+      logger: silentLogger,
+    });
+
+    const installed = read(join(userHome, ".codex", "config.toml"));
+    expect(installed.startsWith(existing)).toBe(true);
+    expect(installed.slice(existing.length)).toContain("[mcp_servers]");
+    expect(readMergeableConfig(join(userHome, ".codex", "config.toml"))).toMatchObject({
+      model_provider: "headroom",
+      model_providers: { headroom: { requires_openai_auth: true } },
+      mcp_servers: { generated: { command: "node", env: { TOKEN: "generated" } } },
+    });
+  });
+
+  it("merges Codex implicit parents, inline tables, and arrays of tables at the correct paths", async () => {
+    const root = createTempRoot();
+    const sourceDir = join(root, ".ulis");
+    const outputDir = join(sourceDir, "generated");
+    const userHome = join(root, "home");
+    mkdirSync(sourceDir, { recursive: true });
+    mkdirSync(userHome, { recursive: true });
+
+    write(
+      join(outputDir, "codex", "config.toml"),
+      [
+        "[windows]",
+        'sandbox = "elevated"',
+        "",
+        "[mcp_servers.generated]",
+        'command = "node"',
+        "",
+        "[mcp_servers.generated.env]",
+        'TOKEN = "generated"',
+        "",
+        "[[plugins]]",
+        'name = "one"',
+        "",
+        "[[plugins]]",
+        'name = "two"',
+        "",
+      ].join("\n"),
+    );
+    write(
+      join(userHome, ".codex", "config.toml"),
+      [
+        "# keep this comment",
+        'mcp_servers = { keep = { command = "old" } }',
+        "",
+        "[windows.policy]",
+        "enabled = true",
+        "",
+      ].join("\n"),
+    );
+
+    await runInstall({
+      sourceDir,
+      outputDir,
+      destBase: userHome,
+      userHome,
+      platforms: ["codex"],
+      rebuild: false,
+      logger: silentLogger,
+    });
+
+    const installedPath = join(userHome, ".codex", "config.toml");
+    expect(read(installedPath)).toContain("# keep this comment");
+    expect(readMergeableConfig(installedPath)).toEqual({
+      mcp_servers: {
+        keep: { command: "old" },
+        generated: { command: "node", env: { TOKEN: "generated" } },
+      },
+      windows: { policy: { enabled: true }, sandbox: "elevated" },
+      plugins: [{ name: "one" }, { name: "two" }],
+    });
+  });
+
+  it("replaces conflicting Codex table and array-of-tables representations", async () => {
+    const cases = [
+      {
+        existing: ["# keep table transition", "unrelated = true", "", "[plugins]", 'name = "old"', ""].join("\n"),
+        generated: ["[[plugins]]", 'name = "new"', ""].join("\n"),
+        expected: [{ name: "new" }],
+      },
+      {
+        existing: ["# keep inline transition", "unrelated = true", 'plugins = [{ name = "old" }]', ""].join("\n"),
+        generated: ["[[plugins]]", 'name = "new"', ""].join("\n"),
+        expected: [{ name: "new" }],
+      },
+      {
+        existing: ["# keep array transition", "unrelated = true", "", "[[plugins]]", 'name = "old"', ""].join("\n"),
+        generated: ["[plugins]", 'name = "new"', ""].join("\n"),
+        expected: { name: "new" },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const root = createTempRoot();
+      const sourceDir = join(root, ".ulis");
+      const outputDir = join(sourceDir, "generated");
+      const userHome = join(root, "home");
+      mkdirSync(sourceDir, { recursive: true });
+      mkdirSync(userHome, { recursive: true });
+      write(join(outputDir, "codex", "config.toml"), testCase.generated);
+      write(join(userHome, ".codex", "config.toml"), testCase.existing);
+
+      await runInstall({
+        sourceDir,
+        outputDir,
+        destBase: userHome,
+        userHome,
+        platforms: ["codex"],
+        rebuild: false,
+        logger: silentLogger,
+      });
+
+      const installedPath = join(userHome, ".codex", "config.toml");
+      const installed = read(installedPath);
+      expect(installed).toContain(testCase.existing.split("\n")[0]!);
+      expect(readMergeableConfig(installedPath)).toEqual({
+        unrelated: true,
+        plugins: testCase.expected,
+      });
+    }
+  });
+
+  it("preserves native config across platform installs", async () => {
     const root = createTempRoot();
     const sourceDir = join(root, ".ulis");
     const outputDir = join(sourceDir, "generated");
@@ -283,7 +461,9 @@ describe("runInstall", () => {
     });
 
     expect(JSON.parse(read(join(projectDir, ".claude", "settings.json")))).toEqual({
+      env: { OLD: "1" },
       hooks: { PreToolUse: [{ matcher: "existing" }] },
+      mcpServers: { old: { command: "old" } },
       statusLine: { type: "command", command: "bash ~/.claude/statusline.sh" },
       enabledPlugins: { "plugin@example": true },
       extraKnownMarketplaces: { example: { source: { source: "github", repo: "owner/repo" } } },
@@ -368,7 +548,7 @@ describe("runInstall", () => {
     expect(existsSync(join(projectDir, ".opencode", "opencode.json"))).toBe(false);
   });
 
-  it("removes stale Codex config when generated config is absent and no allowlisted keys exist", async () => {
+  it("leaves existing Codex config unchanged when generated config is absent", async () => {
     const root = createTempRoot();
     const sourceDir = join(root, ".ulis");
     const outputDir = join(sourceDir, "generated");
@@ -391,7 +571,7 @@ describe("runInstall", () => {
     });
 
     expect(read(join(projectDir, ".codex", "AGENTS.md"))).toBe("Generated instructions.\n");
-    expect(existsSync(join(projectDir, ".codex", "config.toml"))).toBe(false);
+    expect(read(join(projectDir, ".codex", "config.toml"))).toBe('model = "old"\n');
   });
 
   it("backs up existing config before failing to parse preserved native config", async () => {
@@ -1060,12 +1240,12 @@ describe("runInstall", () => {
     });
   });
 
-  it("preserves user-owned keys in ~/.claude.json on global install and replaces mcpServers wholesale", async () => {
+  it("overlays generated MCP servers into ~/.claude.json without removing unmanaged servers", async () => {
     // Regression: ULIS used to capture only the `mcpServers` slice of an
     // existing ~/.claude.json and write back just that slice, wiping every
     // other key (projects, enabledPlugins, theme, history, ...). Global Claude
-    // installs must preserve those user-owned keys verbatim and overwrite only
-    // the mcpServers block, which ULIS owns.
+    // installs must preserve user-owned keys and unmanaged MCP servers while
+    // overwriting generated values at the same paths.
     const root = createTempRoot();
     const sourceDir = join(root, ".ulis");
     const outputDir = join(sourceDir, "generated");
@@ -1088,7 +1268,7 @@ describe("runInstall", () => {
           enabledPlugins: { "marketplace@example": true },
           autoUpdatesChannel: "latest",
           telemetryStatus: "enabled",
-          // ULIS-owned mcpServers slice (will be replaced):
+          // Existing MCP servers are merged by name:
           mcpServers: { existing: { command: "old" }, shared: { command: "old" } },
         },
         null,
@@ -1106,14 +1286,17 @@ describe("runInstall", () => {
       logger: silentLogger,
     });
 
-    // Every user-owned key survives verbatim; mcpServers comes entirely from generated.
+    // Existing state and unmanaged MCP servers survive; generated conflicts win.
     expect(JSON.parse(read(join(userHome, ".claude.json")))).toEqual({
       theme: "dark",
       projects: { "/home/me/repo": { lastModified: "2026-05-15", history: ["msg1", "msg2"] } },
       enabledPlugins: { "marketplace@example": true },
       autoUpdatesChannel: "latest",
       telemetryStatus: "enabled",
-      mcpServers: { shared: { command: "generated" } },
+      mcpServers: {
+        existing: { command: "old" },
+        shared: { command: "generated" },
+      },
     });
   });
 
@@ -1150,10 +1333,11 @@ describe("runInstall", () => {
       logger: silentLogger,
     });
 
-    // mcpServers (ULIS-owned) is removed; user-owned keys survive.
+    // No generated file means the existing file is left unchanged.
     expect(JSON.parse(read(join(userHome, ".claude.json")))).toEqual({
       theme: "dark",
       projects: { "/home/me/repo": { lastModified: "2026-05-15" } },
+      mcpServers: { stale: { command: "old" } },
     });
   });
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -45,6 +45,8 @@ export interface InstallOptions {
   readonly runner?: InstallRunner;
   /** When false, skip running extensions installers (`extensions.yaml`). */
   readonly installExtensions?: boolean;
+  /** When false, skip installing external skills (`skills.yaml`). */
+  readonly installSkills?: boolean;
 }
 
 export interface PresetInstallOptions {
@@ -62,6 +64,8 @@ export interface PresetInstallOptions {
   readonly runner?: InstallRunner;
   /** When false, skip running extensions installers (`extensions.yaml`). */
   readonly installExtensions?: boolean;
+  /** When false, skip installing external skills (`skills.yaml`). */
+  readonly installSkills?: boolean;
   readonly signal?: AbortSignal;
 }
 
@@ -79,7 +83,8 @@ interface AsyncCommandResult {
 }
 
 type SkillInstallLog =
-  { readonly level: "success"; readonly message: string } | { readonly level: "warn"; readonly message: string };
+  | { readonly level: "success"; readonly message: string }
+  | { readonly level: "warn"; readonly message: string };
 
 type RunAsyncCommand = (
   command: string,
@@ -103,6 +108,7 @@ interface GeneratedInstallOptions {
   readonly extensionsConfig: ExtensionsConfig;
   readonly runner: InstallRunner;
   readonly installExtensionsEnabled: boolean;
+  readonly installSkillsEnabled: boolean;
   readonly logger: Logger;
   readonly signal?: AbortSignal;
 }
@@ -204,6 +210,7 @@ export async function runInstall(options: InstallOptions): Promise<readonly Plat
   ]);
 
   const installExtensionsEnabled = options.installExtensions ?? true;
+  const installSkillsEnabled = options.installSkills ?? true;
   const ulisConfig = loadValidatedConfigFile({
     dir: sourceDir,
     baseName: "config",
@@ -223,6 +230,7 @@ export async function runInstall(options: InstallOptions): Promise<readonly Plat
     extensionsConfig,
     runner,
     installExtensionsEnabled,
+    installSkillsEnabled,
     logger,
   });
 
@@ -246,6 +254,7 @@ export async function runPresetInstall(options: PresetInstallOptions): Promise<r
   const globalInstall = options.globalInstall ?? isSamePath(destBase, userHome);
   const backup = options.backup ?? false;
   const installExtensionsEnabled = options.installExtensions ?? true;
+  const installSkillsEnabled = options.installSkills ?? true;
   const runner = resolveRunner({ cliFlag: options.runner });
   const tempRoot = mkdtempSync(join(tmpdir(), "ulis-preset-install-"));
   const outputDir = join(tempRoot, ULIS_GENERATED_DIRNAME);
@@ -289,6 +298,7 @@ export async function runPresetInstall(options: PresetInstallOptions): Promise<r
       extensionsConfig,
       runner,
       installExtensionsEnabled,
+      installSkillsEnabled,
       logger,
       signal: options.signal,
     });
@@ -337,34 +347,36 @@ async function installGeneratedOutput(options: GeneratedInstallOptions): Promise
     }
   }
 
-  for (const platform of options.platforms) {
-    throwIfAborted(options.signal);
-    const platformSkills = options.skillsConfig[platform]?.skills ?? [];
-    if (platformSkills.length > 0) {
+  if (options.installSkillsEnabled) {
+    for (const platform of options.platforms) {
+      throwIfAborted(options.signal);
+      const platformSkills = options.skillsConfig[platform]?.skills ?? [];
+      if (platformSkills.length > 0) {
+        await installSkills(
+          platformSkills,
+          platform,
+          options.destBase,
+          options.globalInstall,
+          options.logger,
+          [],
+          options.signal,
+        );
+      }
+    }
+
+    const allSkills = options.skillsConfig["*"]?.skills ?? [];
+    if (allSkills.length > 0) {
+      logHeader(options.logger, "Installing External Skills");
       await installSkills(
-        platformSkills,
-        platform,
+        allSkills,
+        "*",
         options.destBase,
         options.globalInstall,
         options.logger,
-        [],
+        options.platforms,
         options.signal,
       );
     }
-  }
-
-  const allSkills = options.skillsConfig["*"]?.skills ?? [];
-  if (allSkills.length > 0) {
-    logHeader(options.logger, "Installing External Skills");
-    await installSkills(
-      allSkills,
-      "*",
-      options.destBase,
-      options.globalInstall,
-      options.logger,
-      options.platforms,
-      options.signal,
-    );
   }
 
   if (!options.installExtensionsEnabled) return;

--- a/src/tui/actions.test.ts
+++ b/src/tui/actions.test.ts
@@ -165,7 +165,7 @@ describe("tui actions child process flow", () => {
     expect(args).toContain("codex");
     expect(args).toContain("--yes");
     expect(args).toContain("--global");
-    expect(args).toContain("--no-rebuild");
+    expect(args).toContain("--skip-rebuild");
     expect(args).toContain("--backup");
   });
 

--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -78,6 +78,7 @@ export async function runTuiAction(
       logger,
       presets,
       installExtensions: state.presetInstallExtensions,
+      installSkills: !state.skipExternalSkills,
       signal: options.signal,
     });
     return;
@@ -120,8 +121,9 @@ async function runActionInChildProcess(
   if (action === "install") {
     args.push("--yes");
     if (planSource(state).globalInstall) args.push("--global");
-    if (!state.rebuild) args.push("--no-rebuild");
+    if (!state.rebuild) args.push("--skip-rebuild");
     if (state.backup) args.push("--backup");
+    if (state.skipExternalSkills) args.push("--skip-external-skills");
   }
 
   await new Promise<void>((resolve, reject) => {

--- a/src/tui/preferences.test.ts
+++ b/src/tui/preferences.test.ts
@@ -163,6 +163,7 @@ describe("tui preferences", () => {
           backup: false,
           rebuild: false,
           presetInstallExtensions: true,
+          skipExternalSkills: false,
         },
       },
     });

--- a/src/tui/preferences.ts
+++ b/src/tui/preferences.ts
@@ -194,6 +194,9 @@ function sanitizeFlowPreferences(raw: Record<string, unknown>): TuiFlowPreferenc
   if (typeof raw.presetInstallExtensions === "boolean") {
     next.presetInstallExtensions = raw.presetInstallExtensions;
   }
+  if (typeof raw.skipExternalSkills === "boolean") {
+    next.skipExternalSkills = raw.skipExternalSkills;
+  }
 
   return next;
 }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -135,15 +135,22 @@ function renderPlan(state: TuiState) {
     { text: `${presetLabel}: `, inlineValue: formatPresets(state) },
     state.flow === "presetsOnly"
       ? { text: "Base source: ", inlineValue: "none (preset-only install)" }
-      : { text: "Base source: ", inlineValue: `${formatSourceMode(state.sourceMode, state.customSource)} -> ${plan.sourceDir}` },
+      : {
+          text: "Base source: ",
+          inlineValue: `${formatSourceMode(state.sourceMode, state.customSource)} -> ${plan.sourceDir}`,
+        },
     { text: "" },
     { text: "Output", fgColor: "color06", bold: true },
     { text: "Platforms: ", inlineValue: formatPlatforms(state.platforms) },
-    { text: "Install destination: ", inlineValue: `${formatDestinationMode(state.destinationMode)} -> ${plan.destBase}` },
+    {
+      text: "Install destination: ",
+      inlineValue: `${formatDestinationMode(state.destinationMode)} -> ${plan.destBase}`,
+    },
     { text: "" },
     { text: "Install options", fgColor: "color06", bold: true },
     { text: "Backup: ", inlineValue: state.backup ? "on" : "off" },
     { text: "Use latest build output: ", inlineValue: state.rebuild ? "on" : "off" },
+    { text: "Skip external skills: ", inlineValue: state.skipExternalSkills ? "on" : "off" },
   ];
 
   return renderCardShell(
@@ -174,6 +181,7 @@ function planLabel(state: TuiState, label: TuiPlanItem): string {
   if (label === "Backup") return state.backup ? "on" : "off";
   if (label === "Use latest build output") return state.rebuild ? "on" : "off";
   if (label === "Run preset extensions") return state.presetInstallExtensions ? "on" : "off";
+  if (label === "Skip external skills") return state.skipExternalSkills ? "on" : "off";
   return label;
 }
 
@@ -250,10 +258,7 @@ function renderUiLine(line: UiLine): Node {
         alignItems: "start",
         justifyContent: "start",
       },
-      [
-        Text(line.text, { bold: line.bold, wrap: "word" }),
-        Text(line.inlineValue, { bold: true, wrap: "word" }),
-      ],
+      [Text(line.text, { bold: line.bold, wrap: "word" }), Text(line.inlineValue, { bold: true, wrap: "word" })],
     );
   }
   return line.value == null
@@ -533,8 +538,9 @@ function formatInstallCommand(state: TuiState): string {
   const args = ["ulis", "install", "--source", plan.sourceDir, "--target", state.platforms.join(","), "--yes"];
   if (state.destinationMode === "global") args.push("--global");
   if (state.selectedPresetNames.length > 0) args.push("--preset", state.selectedPresetNames.join(","));
-  if (!state.rebuild) args.push("--no-rebuild");
+  if (!state.rebuild) args.push("--skip-rebuild");
   if (state.backup) args.push("--backup");
+  if (state.skipExternalSkills) args.push("--skip-external-skills");
   return args.map(quoteCommandArg).join(" ");
 }
 

--- a/src/tui/state.test.ts
+++ b/src/tui/state.test.ts
@@ -84,7 +84,7 @@ describe("tui state", () => {
     try {
       const state = createInitialState();
       state.screen = "plan";
-      state.cursor = 6;
+      state.cursor = 7;
 
       expect(handleTuiKey(state, "enter")).toEqual({ type: "start", action: "validate" });
     } finally {
@@ -100,7 +100,7 @@ describe("tui state", () => {
     try {
       const state = createInitialState();
       state.screen = "plan";
-      state.cursor = 8;
+      state.cursor = 9;
 
       expect(handleTuiKey(state, "enter")).toEqual({ type: "none" });
       expect(state.screen as string).toBe("installReview");
@@ -116,7 +116,7 @@ describe("tui state", () => {
     try {
       const state = createInitialState();
       state.screen = "plan";
-      state.cursor = 7;
+      state.cursor = 8;
 
       expect(handleTuiKey(state, "enter")).toEqual({ type: "none" });
       expect(state.screen as string).toBe("missingSource");
@@ -199,11 +199,11 @@ describe("tui state", () => {
     Date.now = () => now;
 
     try {
-      state.cursor = 5;
+      state.cursor = 6;
       expect(handleTuiKey(state, "enter")).toEqual({ type: "start", action: "presetValidate" });
 
       now += 45;
-      state.cursor = 6;
+      state.cursor = 7;
       expect(handleTuiKey(state, "enter")).toEqual({ type: "none" });
       expect(state.screen as string).toBe("presetInstallReview");
     } finally {

--- a/src/tui/state.ts
+++ b/src/tui/state.ts
@@ -35,6 +35,7 @@ export type TuiPlanItem =
   | "Backup"
   | "Use latest build output"
   | "Run preset extensions"
+  | "Skip external skills"
   | "Validate"
   | "Build only"
   | "Install"
@@ -59,6 +60,7 @@ export interface TuiFlowPreferences {
   readonly backup?: boolean;
   readonly rebuild?: boolean;
   readonly presetInstallExtensions?: boolean;
+  readonly skipExternalSkills?: boolean;
 }
 
 export interface TuiState {
@@ -78,6 +80,7 @@ export interface TuiState {
   backup: boolean;
   rebuild: boolean;
   presetInstallExtensions: boolean;
+  skipExternalSkills: boolean;
   flowPreferences: Partial<Record<TuiPreferenceScope, TuiFlowPreferences>>;
   logs: string[];
   notice: string;
@@ -110,6 +113,7 @@ export const DASHBOARD_ITEMS: readonly TuiPlanItem[] = [
   "Install destination",
   "Backup",
   "Use latest build output",
+  "Skip external skills",
   "Validate",
   "Build only",
   "Install",
@@ -122,6 +126,7 @@ const PRESET_ONLY_PLAN_ITEMS: readonly TuiPlanItem[] = [
   "Install destination",
   "Backup",
   "Run preset extensions",
+  "Skip external skills",
   "Validate",
   "Install",
   "Back to start",
@@ -154,6 +159,7 @@ export function createInitialState(availablePresets: readonly PresetListEntry[] 
     backup: true,
     rebuild: true,
     presetInstallExtensions: true,
+    skipExternalSkills: false,
     flowPreferences: {},
     logs: [],
     notice: "",
@@ -356,6 +362,7 @@ export function flowPreferencesFromState(state: TuiState): TuiFlowPreferences {
     backup: state.backup,
     rebuild: state.rebuild,
     presetInstallExtensions: state.presetInstallExtensions,
+    skipExternalSkills: state.skipExternalSkills,
   };
 
   if (state.flow === "custom" && state.customSource) preferences.customSource = state.customSource;
@@ -404,6 +411,9 @@ export function applyFlowPreferences(state: TuiState, flow: TuiFlow = state.flow
   if (typeof preferences.rebuild === "boolean") state.rebuild = preferences.rebuild;
   if (typeof preferences.presetInstallExtensions === "boolean") {
     state.presetInstallExtensions = preferences.presetInstallExtensions;
+  }
+  if (typeof preferences.skipExternalSkills === "boolean") {
+    state.skipExternalSkills = preferences.skipExternalSkills;
   }
 }
 
@@ -547,6 +557,12 @@ function handlePlanKey(state: TuiState, key: string): TuiEffect {
     return { type: "none" };
   }
 
+  if (item === "Skip external skills" && isToggleKey(key)) {
+    state.skipExternalSkills = !state.skipExternalSkills;
+    state.notice = "";
+    return { type: "none" };
+  }
+
   if (item === "Install destination" && isToggleKey(key)) {
     state.destinationMode = state.destinationMode === "global" ? "project" : "global";
     state.notice = "";
@@ -581,6 +597,9 @@ function handlePlanKey(state: TuiState, key: string): TuiEffect {
       break;
     case "Run preset extensions":
       state.presetInstallExtensions = !state.presetInstallExtensions;
+      break;
+    case "Skip external skills":
+      state.skipExternalSkills = !state.skipExternalSkills;
       break;
     case "Validate":
       if (state.flow === "presetsOnly") return startPresetOnlyAction(state, "presetValidate");

--- a/src/utils/config-merger.test.ts
+++ b/src/utils/config-merger.test.ts
@@ -108,6 +108,7 @@ describe("preserved native config registry", () => {
           ["theme"],
         ],
         ownership: "file",
+        overlay: "json",
       },
       {
         label: ".claude.json / .mcp.json",
@@ -124,6 +125,7 @@ describe("preserved native config registry", () => {
         targetPath: join("root", "project", ".codex", "config.toml"),
         preservedPaths: [["projects"], ["hooks"], ["mcp_servers"], ["tui"], ["notice"], ["features"]],
         ownership: "file",
+        overlay: "toml",
       },
       {
         label: "mcp.json",
@@ -149,10 +151,9 @@ describe("preserved native config registry", () => {
     ]);
   });
 
-  it("switches Claude's .claude.json/.mcp.json entry to ownership: 'paths' for global installs", () => {
+  it("enables full overlay only for global .claude.json installs", () => {
     // When destBase === userHome (global install), the target is `~/.claude.json`
-    // — a file Claude Code owns. ULIS owns ONLY the `mcpServers` path; every
-    // other key (theme, projects, plugins, history) must survive across installs.
+    // and generated values overlay the complete existing object.
     const globalContext = {
       outputDir: join("root", ".ulis", "generated"),
       destBase: join("root", "home"),
@@ -167,6 +168,7 @@ describe("preserved native config registry", () => {
       targetPath: join("root", "home", ".claude.json"),
       preservedPaths: [["mcpServers"]],
       ownership: "paths",
+      overlay: "json",
     });
   });
 });

--- a/src/utils/config-merger.ts
+++ b/src/utils/config-merger.ts
@@ -1,6 +1,8 @@
 import { cpSync, existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import { extname, join } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 
+import { patch as patchToml, TomlDocument, TomlFormat } from "@decimalturn/toml-patch";
 import * as smolToml from "smol-toml";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
@@ -27,6 +29,115 @@ export function mergeConfigValues(base: unknown, override: unknown): unknown {
     result[key] = mergeConfigValues(result[key], value);
   }
   return result;
+}
+
+function patchTomlOverlay(existingContent: string, generatedContent: string, merged: unknown): string {
+  const format = TomlFormat.autoDetectFormat(existingContent);
+  const compatibleContent = removeConflictingTomlRepresentations(existingContent, generatedContent);
+  const arraySeededContent = seedMissingTomlTables(compatibleContent, generatedContent, "array");
+  let retryContent = arraySeededContent;
+  let retryFilter: ((header: TomlTableHeader) => boolean) | undefined;
+  try {
+    const patched = patchToml(arraySeededContent, merged, format);
+    const patchedConfig = smolToml.parse(patched);
+    if (isDeepStrictEqual(patchedConfig, merged)) return patched;
+    retryContent = patched;
+    retryFilter = ({ path }) => !isDeepStrictEqual(getConfigPath(patchedConfig, path), getConfigPath(merged, path));
+  } catch {
+    // Missing nested tables are seeded below before retrying.
+  }
+
+  const seededContent = seedMissingTomlTables(retryContent, generatedContent, "table", retryFilter);
+  const patched = patchToml(seededContent, merged, format);
+  if (!isDeepStrictEqual(smolToml.parse(patched), merged)) {
+    throw new Error("TOML patch did not produce the requested merged config");
+  }
+  return patched;
+}
+
+function removeConflictingTomlRepresentations(existingContent: string, generatedContent: string): string {
+  const desiredKinds = new Map(
+    tomlTableHeaders(generatedContent).map(({ kind, path }) => [JSON.stringify(path), kind]),
+  );
+  if (desiredKinds.size === 0) return existingContent;
+
+  const removals: Array<{ start: number; end: number }> = [];
+  const lineOffsets = tomlLineOffsets(existingContent);
+  const addRemoval = (loc: { start: { line: number; column: number }; end: { line: number; column: number } }) => {
+    const start = lineOffsets[loc.start.line - 1]! + loc.start.column;
+    let end = lineOffsets[loc.end.line - 1]! + loc.end.column;
+    if (existingContent.startsWith("\r\n", end)) end += 2;
+    else if (existingContent[end] === "\n") end += 1;
+    removals.push({ start, end });
+  };
+
+  for (const block of new TomlDocument(existingContent).cst) {
+    if (block.type === "Table" || block.type === "TableArray") {
+      const tablePath = block.key.item.value;
+      const existingKind = block.type === "TableArray" ? "array" : "table";
+      const desiredKind = desiredKinds.get(JSON.stringify(tablePath));
+      if (desiredKind !== undefined && desiredKind !== existingKind) {
+        addRemoval(block.loc);
+        continue;
+      }
+
+      for (const item of block.items) {
+        if (item.type !== "KeyValue") continue;
+        if (desiredKinds.has(JSON.stringify([...tablePath, ...item.key.value]))) addRemoval(item.loc);
+      }
+    } else if (block.type === "KeyValue" && desiredKinds.has(JSON.stringify(block.key.value))) {
+      addRemoval(block.loc);
+    }
+  }
+
+  return removals
+    .sort((left, right) => right.start - left.start)
+    .reduce((content, { start, end }) => content.slice(0, start) + content.slice(end), existingContent);
+}
+
+function tomlLineOffsets(content: string): number[] {
+  const offsets = [0];
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] === "\n") offsets.push(index + 1);
+  }
+  return offsets;
+}
+
+function seedMissingTomlTables(
+  existingContent: string,
+  generatedContent: string,
+  onlyKind?: "array" | "table",
+  shouldSeed?: (header: TomlTableHeader) => boolean,
+): string {
+  const existingHeaders = new Set(tomlTableHeaders(existingContent).map(({ key }) => key));
+  const missingHeaders = tomlTableHeaders(generatedContent)
+    .filter(({ kind }) => onlyKind === undefined || kind === onlyKind)
+    .filter((header) => shouldSeed?.(header) ?? true)
+    .filter(({ key }) => !existingHeaders.has(key))
+    .map(({ line }) => line);
+
+  if (missingHeaders.length === 0) return existingContent;
+  const newline = existingContent.includes("\r\n") ? "\r\n" : "\n";
+  const separator = existingContent.endsWith(newline) ? newline : `${newline}${newline}`;
+  return `${existingContent}${separator}${missingHeaders.join(`${newline}${newline}`)}${newline}`;
+}
+
+interface TomlTableHeader {
+  readonly key: string;
+  readonly kind: "array" | "table";
+  readonly line: string;
+  readonly path: readonly string[];
+}
+
+function tomlTableHeaders(content: string): TomlTableHeader[] {
+  const lines = content.split(/\r?\n/);
+  return new TomlDocument(content).cst.flatMap((block) => {
+    if (block.type !== "Table" && block.type !== "TableArray") return [];
+    const kind = block.type === "TableArray" ? "array" : "table";
+    const path = block.key.item.value;
+    const line = lines[block.loc.start.line - 1]!;
+    return [{ key: `${kind}:${JSON.stringify(path)}`, kind, line, path }];
+  });
 }
 
 const MERGE_EXTS = new Set([".json", ".toml", ".yaml", ".yml"]);
@@ -101,6 +212,7 @@ export interface PreservedNativeConfigContext {
 }
 
 type Ownership = "file" | "paths";
+type OverlayMode = "json" | "toml";
 
 interface PreservedNativeConfigSpec {
   readonly platform: Platform;
@@ -108,6 +220,8 @@ interface PreservedNativeConfigSpec {
   readonly generatedPath: (context: PreservedNativeConfigContext) => string;
   readonly targetPath: (context: PreservedNativeConfigContext) => string;
   readonly preservedPaths: readonly ConfigPath[];
+  /** Preserve the complete existing object as the base, taking precedence over `ownership`. */
+  readonly overlay?: OverlayMode | ((context: PreservedNativeConfigContext) => OverlayMode | undefined);
   /**
    * Ownership model for the target file. May be a literal or context-derived:
    * - "file" (default): ULIS owns the whole file. `preservedPaths` are
@@ -127,10 +241,12 @@ export interface PreservedNativeConfigEntry {
   readonly targetPath: string;
   readonly preservedPaths: readonly ConfigPath[];
   readonly ownership?: Ownership;
+  readonly overlay?: OverlayMode;
 }
 
 export interface CapturedPreservedNativeConfig extends PreservedNativeConfigEntry {
   readonly preservedConfig: unknown | undefined;
+  readonly originalContent?: string;
 }
 
 export class PreservedNativeConfigParseError extends Error {
@@ -165,6 +281,7 @@ export const PRESERVED_NATIVE_CONFIGS = [
       ["agentPushNotifEnabled"],
       ["theme"],
     ],
+    overlay: "json",
   },
   {
     platform: "claude",
@@ -176,20 +293,18 @@ export const PRESERVED_NATIVE_CONFIGS = [
     //   contributes `mcpServers`).
     // - Project install (<cwd>): project-scope `<cwd>/.mcp.json` (committed, just `{ mcpServers }`).
     // The generated `.claude.json` content (`{ mcpServers: {...} }`) fits both formats.
-    // Ownership differs by mode:
-    // - Global (~/.claude.json): "paths" — ULIS owns ONLY `mcpServers`. Every
-    //   other key (projects, enabledPlugins, theme, history, telemetry, ...)
-    //   is preserved verbatim across installs. Critical: without this, Claude
-    //   Code's user-scope state is wiped on every install.
+    // Merge behavior differs by mode:
+    // - Global (~/.claude.json): overlay generated MCP values onto the complete
+    //   existing file, preserving all absent keys and unmanaged MCP servers.
     // - Project (<cwd>/.mcp.json): "file" — the file is just `{ mcpServers }`,
-    //   and we want to merge generated servers on top of any user/team-added
-    //   ones already in the file.
+    //   retaining the existing selective merge behavior.
     targetPath: (context) =>
       isSamePath(context.destBase, context.userHome)
         ? join(context.destBase, ".claude.json")
         : join(context.destBase, ".mcp.json"),
     preservedPaths: [["mcpServers"]],
     ownership: (context) => (isSamePath(context.destBase, context.userHome) ? "paths" : "file"),
+    overlay: (context) => (isSamePath(context.destBase, context.userHome) ? "json" : undefined),
   },
   {
     platform: "codex",
@@ -197,6 +312,7 @@ export const PRESERVED_NATIVE_CONFIGS = [
     generatedPath: (context) => join(context.outputDir, "codex", "config.toml"),
     targetPath: (context) => join(platformConfigDir("codex", context.destBase, context.userHome), "config.toml"),
     preservedPaths: [["projects"], ["hooks"], ["mcp_servers"], ["tui"], ["notice"], ["features"]],
+    overlay: "toml",
   },
   {
     platform: "cursor",
@@ -229,12 +345,15 @@ export function getPreservedNativeConfigEntries(
   return PRESERVED_NATIVE_CONFIGS.filter((spec) => spec.platform === platform).map((spec) => {
     const rawOwnership = "ownership" in spec ? spec.ownership : undefined;
     const ownership: Ownership = typeof rawOwnership === "function" ? rawOwnership(context) : (rawOwnership ?? "file");
+    const rawOverlay = "overlay" in spec ? spec.overlay : undefined;
+    const overlay = typeof rawOverlay === "function" ? rawOverlay(context) : rawOverlay;
     return {
       label: spec.label,
       generatedPath: spec.generatedPath(context),
       targetPath: spec.targetPath(context),
       preservedPaths: spec.preservedPaths,
       ownership,
+      ...(overlay ? { overlay } : {}),
     };
   });
 }
@@ -243,10 +362,10 @@ export function capturePreservedNativeConfigs(
   platform: Platform,
   context: PreservedNativeConfigContext,
 ): readonly CapturedPreservedNativeConfig[] {
-  return getPreservedNativeConfigEntries(platform, context).map((entry) => ({
-    ...entry,
-    preservedConfig: capturePreservedConfig(entry),
-  }));
+  return getPreservedNativeConfigEntries(platform, context).map((entry) => {
+    const captured = capturePreservedConfig(entry);
+    return { ...entry, ...captured };
+  });
 }
 
 export function writePreservedNativeConfigs(
@@ -258,19 +377,30 @@ export function writePreservedNativeConfigs(
   }
 }
 
-function capturePreservedConfig(entry: PreservedNativeConfigEntry): unknown | undefined {
-  if (!existsSync(entry.targetPath)) return undefined;
-  let preserved: Record<string, unknown>;
+function capturePreservedConfig(
+  entry: PreservedNativeConfigEntry,
+): Pick<CapturedPreservedNativeConfig, "preservedConfig" | "originalContent"> {
+  if (!existsSync(entry.targetPath)) return { preservedConfig: undefined };
+
   try {
     const existing = readMergeableConfig(entry.targetPath);
-    preserved =
+    if (entry.overlay) {
+      return {
+        preservedConfig: existing,
+        ...(entry.overlay === "toml" ? { originalContent: readFile(entry.targetPath) } : {}),
+      };
+    }
+
+    const preserved =
       entry.ownership === "paths"
         ? omitConfigPaths(existing, entry.preservedPaths)
         : pickConfigPaths(existing, entry.preservedPaths);
+    return {
+      preservedConfig: Object.keys(preserved).length > 0 ? preserved : undefined,
+    };
   } catch (error) {
     throw new PreservedNativeConfigParseError(entry.targetPath, error);
   }
-  return Object.keys(preserved).length > 0 ? preserved : undefined;
 }
 
 export function pickConfigPaths(source: unknown, paths: readonly ConfigPath[]): Record<string, unknown> {
@@ -340,6 +470,10 @@ function setConfigPath(target: Record<string, unknown>, path: readonly string[],
 function writePreservedNativeConfig(entry: CapturedPreservedNativeConfig, logger?: PreservedNativeConfigLogger): void {
   try {
     if (!existsSync(entry.generatedPath)) {
+      if (entry.overlay && existsSync(entry.targetPath)) {
+        logger?.success(`${entry.label} (preserved)`);
+        return;
+      }
       if (entry.preservedConfig !== undefined) {
         writeMergeableConfig(entry.targetPath, entry.preservedConfig);
         logger?.success(`${entry.label} (preserved)`);
@@ -356,8 +490,15 @@ function writePreservedNativeConfig(entry: CapturedPreservedNativeConfig, logger
       return;
     }
 
+    const generatedContent = readFile(entry.generatedPath);
     const generated = readMergeableConfig(entry.generatedPath);
-    writeMergeableConfig(entry.targetPath, mergeConfigValues(entry.preservedConfig, generated));
+    const merged = mergeConfigValues(entry.preservedConfig, generated);
+    if (entry.overlay === "toml") {
+      const existingContent = entry.originalContent ?? readFile(entry.targetPath);
+      writeFile(entry.targetPath, patchTomlOverlay(existingContent, generatedContent, merged));
+    } else {
+      writeMergeableConfig(entry.targetPath, merged);
+    }
     logger?.success(`${entry.label} (merged)`);
   } catch (error) {
     throw new Error(`Failed to merge preserved native config ${entry.generatedPath} -> ${entry.targetPath}`, {


### PR DESCRIPTION
Adds a CLI/TUI option to skip installing external skills declared in
skills.yaml. Also renames --no-rebuild/--no-extensions to
--skip-rebuild/--skip-extensions so all disable flags share one
--skip-* convention, and fixes --target/--runner placeholders plus a
~/.forge/ typo in help text.