### PR TITLE
fix: preserve Codex skill agent metadata

### DIFF
--- a/src/generators/platforms/codex/index.ts
+++ b/src/generators/platforms/codex/index.ts
@@ -13,6 +13,7 @@ import { buildCodexSkillArtifacts } from "./skills.js";
 
 export function generateCodex(project: ProjectBundle): GenerationResult {
   const artifacts: FileArtifact[] = [];
+  const enabledSkills = enabledSkillsFor(project.skills, "codex");
 
   artifacts.push({ path: "config.toml", contents: buildCodexConfigToml(project) });
 
@@ -20,7 +21,7 @@ export function generateCodex(project: ProjectBundle): GenerationResult {
     artifacts.push(buildCodexAgentArtifact(agent));
   }
 
-  for (const skill of enabledSkillsFor(project.skills, "codex")) {
+  for (const skill of enabledSkills) {
     artifacts.push(...buildCodexSkillArtifacts(skill));
   }
 
@@ -43,7 +44,7 @@ export function generateCodex(project: ProjectBundle): GenerationResult {
     post: {
       rawDirs: rawDirs(project, "codex"),
       aliasFiles: [],
-      skillDirs: [],
+      skillDirs: enabledSkills.map(({ name, dir }) => ({ name, dir })),
       appendAfterRaw,
     },
   };

--- a/src/generators/writer.test.ts
+++ b/src/generators/writer.test.ts
@@ -56,6 +56,7 @@ describe("writeResult", () => {
         "\n",
       ),
     );
+    write(join(skillDir, "agents", "openai.yaml"), "interface:\n  display_name: Source Skill\n");
 
     writeResult(
       {
@@ -75,6 +76,9 @@ describe("writeResult", () => {
     expect(copied).toContain("model: gpt-test");
     expect(copied).not.toContain("allowImplicitInvocation");
     expect(copied).toContain("Skill body.");
+    expect(read(join(outDir, "skills", "copied-skill", "agents", "openai.yaml"))).toContain(
+      "display_name: Source Skill",
+    );
   });
 
   it("copies skill directories into a custom skills destination", () => {
@@ -98,6 +102,29 @@ describe("writeResult", () => {
     );
 
     expect(read(join(outDir, ".forge", "skills", "forge-skill", "SKILL.md"))).toBe("Skill body.\n");
+  });
+
+  it("applies generated artifacts over copied skill files", () => {
+    const root = createTempRoot("ulis-writer-");
+    const outDir = join(root, "out");
+    const skillDir = join(root, "source-skill");
+    write(join(skillDir, "SKILL.md"), "Skill body.");
+    write(join(skillDir, "agents", "openai.yaml"), "source: true\n");
+
+    writeResult(
+      {
+        artifacts: [{ path: join("skills", "copied-skill", "agents", "openai.yaml"), contents: "generated: true\n" }],
+        post: {
+          rawDirs: [],
+          aliasFiles: [],
+          skillDirs: [{ name: "copied-skill", dir: skillDir }],
+        },
+      },
+      outDir,
+      "codex",
+    );
+
+    expect(read(join(outDir, "skills", "copied-skill", "agents", "openai.yaml"))).toBe("generated: true\n");
   });
 
   it("copies existing copyDirs and skips missing ones", () => {

--- a/src/generators/writer.ts
+++ b/src/generators/writer.ts
@@ -10,8 +10,9 @@ import type { GenerationResult } from "./types.js";
 /**
  * Apply a pure `GenerationResult` to disk under `outDir`:
  * 1. Clear the out dir.
- * 2. Write each `FileArtifact` (path is resolved relative to `outDir`).
- * 3. Copy skill directories, merge raw source trees, and write AGENTS.md aliases.
+ * 2. Copy skill directories.
+ * 3. Write each `FileArtifact` (path is resolved relative to `outDir`).
+ * 4. Merge raw source trees and write AGENTS.md aliases.
  *
  * Pure generation (the `artifacts` array) is byte-for-byte reproducible and
  * snapshot-testable. This function owns the only filesystem side effects.
@@ -24,14 +25,14 @@ export function writeResult(
 ): void {
   cleanDir(outDir);
 
-  for (const artifact of result.artifacts) {
-    writeFile(resolveArtifactPath(outDir, artifact.path), artifact.contents as string);
-  }
-
   if (result.post.skillDirs.length > 0) {
     const skillsDest = result.post.skillsDestRelative ?? "skills";
     copySkillDirs(result.post.skillDirs, join(outDir, skillsDest));
     logger.success(`${skillsDest}/ (${result.post.skillDirs.length} copied)`);
+  }
+
+  for (const artifact of result.artifacts) {
+    writeFile(resolveArtifactPath(outDir, artifact.path), artifact.contents as string);
   }
 
   for (const copy of result.post.copyDirs ?? []) {

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -64,6 +64,32 @@ afterEach(() => {
 });
 
 describe("runInstall", () => {
+  it("installs Codex skill agent metadata from source skill directories globally", async () => {
+    const root = createTempRoot();
+    const sourceDir = join(root, "source");
+    const openaiYaml = "interface:\n  display_name: Audit Skills\n";
+    write(join(sourceDir, "config.yaml"), "version: 1\nname: test\n");
+    write(
+      join(sourceDir, "skills", "audit-skills", "SKILL.md"),
+      "---\nname: audit-skills\ndescription: Audit skills\n---\nAudit skills.\n",
+    );
+    write(join(sourceDir, "skills", "audit-skills", "agents", "openai.yaml"), openaiYaml);
+
+    await runInstall({
+      sourceDir,
+      destBase: root,
+      userHome: root,
+      globalInstall: true,
+      platforms: ["codex"],
+      rebuild: true,
+      installExtensions: false,
+      installSkills: false,
+      logger: silentLogger,
+    });
+
+    expect(read(join(root, ".codex", "skills", "audit-skills", "agents", "openai.yaml"))).toBe(openaiYaml);
+  });
+
   it("overlays generated Codex values while preserving unmanaged config for project installs", async () => {
     const root = createTempRoot();
     const sourceDir = join(root, ".ulis");


### PR DESCRIPTION
Copy complete local skill directories during Codex generation so nested agents/openai.yaml files reach global installs while generated artifacts retain precedence.