### PR TITLE
fix: merge Claude settings.local.json on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ For the full field-level schema and examples, see [docs/REFERENCE.md](docs/REFER
 
 Generated agent and local skill entries replace destination entries with the same native name. ULIS records their paths in each platform root's `.ulis-manifest.json`; later installs remove tracked paths that are no longer generated while preserving untracked and tool-provided entries. The first manifest-aware install only adopts the current set. Use `--no-prune` to retain stale paths and make them unmanaged. External `skills.yaml` installs are not tracked.
 
-`settings.json`, `.claude.json`, `mcp.json`, and ForgeCode's `.forge/.mcp.json` are deep-merged so user content outside ULIS-managed keys is preserved. With `--backup`, existing platform directories/files, ownership manifests, and entries are copied aside before overwriting or pruning.
+`settings.json`, `settings.local.json`, `.claude.json`, `mcp.json`, and ForgeCode's `.forge/.mcp.json` are deep-merged so user content outside ULIS-managed keys is preserved. With `--backup`, existing platform directories/files, ownership manifests, and entries are copied aside before overwriting or pruning.
 
 `ulis install` runs phases in this order: **build → files → skills → extensions**. Extensions run last because they typically mutate the same files ulis just deployed.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -97,7 +97,7 @@ ulis install [-g | --global] [--source <path>] [--target <platforms>]
 
 | Platform  | Managed entries                                                              | Preserved native config                                                                |
 | --------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Claude    | generated `agents/` and `skills/` entries by name; `commands/`, `rules/`, …  | all `settings.json` and global `.claude.json` values; project `.mcp.json` `mcpServers` |
+| Claude    | generated `agents/` and `skills/` entries by name; `commands/`, `rules/`, …  | all `settings.json` / `settings.local.json` and global `.claude.json` values; project `.mcp.json` `mcpServers` |
 | OpenCode  | generated `agents/core`, `agents/specialized`, and `skills/` entries by name | `opencode.json` `mcp`                                                                  |
 | Codex     | generated `agents/` and `skills/` entries by name                            | all `config.toml` values; unrelated comments and order                                 |
 | Cursor    | generated `agents/` and `skills/` entries by name                            | `mcp.json` `mcpServers`                                                                |
@@ -105,7 +105,7 @@ ulis install [-g | --global] [--source <path>] [--target <platforms>]
 
 Install records generated agents and local skills in `.ulis-manifest.json` at each selected platform config root. On the first manifest-aware install, ULIS adopts the current set and removes nothing. Later installs remove previously tracked paths that are no longer generated, including platform-disabled entries, while preserving every untracked agent or skill. Manifest validation for all selected platforms completes before any destination is modified. Unselected platforms are untouched. `--no-prune` keeps stale paths but refreshes ownership to the current set. External `skills.yaml` installs are not tracked.
 
-For Codex `config.toml`, Claude `settings.json`, and global `.claude.json`, the existing file is the base: generated values overwrite only matching paths, while absent values remain. Other native configs retain their allowlisted preservation rules. Raw fragments win through the generated output because raw is merged during build. If `--backup` is set, backups include the previous manifest and managed entries before pruning.
+For Codex `config.toml`, Claude `settings.json` / `settings.local.json`, and global `.claude.json`, the existing file is the base: generated values overwrite only matching paths, while absent values remain. Other native configs retain their allowlisted preservation rules. Raw fragments win through the generated output because raw is merged during build. If `--backup` is set, backups include the previous manifest and managed entries before pruning.
 
 ---
 

--- a/docs/adr/0001-preserve-native-config-only.md
+++ b/docs/adr/0001-preserve-native-config-only.md
@@ -1,6 +1,6 @@
 # Preserve Native Config by Ownership
 
-ULIS uses base-first overlays for Codex `config.toml`, Claude `settings.json`, and global `.claude.json`. The existing native file is the base, current generated values overwrite matching leaf paths, and values absent from the generated config remain. Codex TOML is patched in place so unrelated comments, formatting, and ordering survive.
+ULIS uses base-first overlays for Codex `config.toml`, Claude `settings.json` and `settings.local.json`, and global `.claude.json`. The existing native file is the base, current generated values overwrite matching leaf paths, and values absent from the generated config remain. Codex TOML is patched in place so unrelated comments, formatting, and ordering survive.
 
 Project `.mcp.json` and other destination-native configs keep their existing allowlisted preservation rules. Raw fragments remain the explicit override and win at the same config path because they are merged into generated output before install.
 

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -569,6 +569,66 @@ describe("runInstall", () => {
     });
   });
 
+  it("merges Claude settings.local.json with the existing file", async () => {
+    const root = createTempRoot();
+    const sourceDir = join(root, ".ulis");
+    const outputDir = join(sourceDir, "generated");
+    const projectDir = join(root, "project");
+    const userHome = join(root, "home");
+    mkdirSync(sourceDir, { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(userHome, { recursive: true });
+    write(join(outputDir, "claude", "settings.json"), "{}");
+    write(
+      join(outputDir, "claude", "settings.local.json"),
+      JSON.stringify({ permissions: { allow: ["Bash(ls:*)"] } }, null, 2),
+    );
+    write(
+      join(projectDir, ".claude", "settings.local.json"),
+      JSON.stringify({ existingLocalKey: true, permissions: { deny: ["Bash(rm:*)"] } }, null, 2),
+    );
+
+    await runInstall({
+      sourceDir,
+      outputDir,
+      destBase: projectDir,
+      userHome,
+      platforms: ["claude"],
+      rebuild: false,
+      logger: silentLogger,
+    });
+
+    expect(JSON.parse(read(join(projectDir, ".claude", "settings.local.json")))).toEqual({
+      existingLocalKey: true,
+      permissions: { deny: ["Bash(rm:*)"], allow: ["Bash(ls:*)"] },
+    });
+  });
+
+  it("leaves an existing Claude settings.local.json untouched when nothing is generated", async () => {
+    const root = createTempRoot();
+    const sourceDir = join(root, ".ulis");
+    const outputDir = join(sourceDir, "generated");
+    const projectDir = join(root, "project");
+    const userHome = join(root, "home");
+    mkdirSync(sourceDir, { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(userHome, { recursive: true });
+    write(join(outputDir, "claude", "settings.json"), "{}");
+    write(join(projectDir, ".claude", "settings.local.json"), JSON.stringify({ keepMe: true }, null, 2));
+
+    await runInstall({
+      sourceDir,
+      outputDir,
+      destBase: projectDir,
+      userHome,
+      platforms: ["claude"],
+      rebuild: false,
+      logger: silentLogger,
+    });
+
+    expect(JSON.parse(read(join(projectDir, ".claude", "settings.local.json")))).toEqual({ keepMe: true });
+  });
+
   it("preserves OpenCode allowlisted config when generated config is absent", async () => {
     const root = createTempRoot();
     const sourceDir = join(root, ".ulis");

--- a/src/install/platforms.ts
+++ b/src/install/platforms.ts
@@ -55,7 +55,7 @@ export async function installClaude(context: InstallContext): Promise<void> {
 
   copyPlatformContents(sourceDir, targetDir, {
     logger: context.logger,
-    skipNames: reservedNames("settings.json", ".claude.json"),
+    skipNames: reservedNames("settings.json", "settings.local.json", ".claude.json"),
     namedDirectories: managedDirectoryRules("claude"),
   });
 }

--- a/src/utils/config-merger.test.ts
+++ b/src/utils/config-merger.test.ts
@@ -111,6 +111,14 @@ describe("preserved native config registry", () => {
         overlay: "json",
       },
       {
+        label: "settings.local.json",
+        generatedPath: join("root", ".ulis", "generated", "claude", "settings.local.json"),
+        targetPath: join("root", "project", ".claude", "settings.local.json"),
+        preservedPaths: [[]],
+        ownership: "file",
+        overlay: "json",
+      },
+      {
         label: ".claude.json / .mcp.json",
         generatedPath: join("root", ".ulis", "generated", "claude", ".claude.json"),
         targetPath: join("root", "project", ".mcp.json"),

--- a/src/utils/config-merger.ts
+++ b/src/utils/config-merger.ts
@@ -287,6 +287,18 @@ export const PRESERVED_NATIVE_CONFIGS = [
   },
   {
     platform: "claude",
+    // Machine-local overrides Claude Code owns. ULIS only contributes what a raw
+    // fragment provides, so the existing file is the base and generated values
+    // overlay on top; with no generated file the user's file is left untouched.
+    label: "settings.local.json",
+    generatedPath: (context) => join(context.outputDir, "claude", "settings.local.json"),
+    targetPath: (context) =>
+      join(platformConfigDir("claude", context.destBase, context.userHome), "settings.local.json"),
+    preservedPaths: [[]],
+    overlay: "json",
+  },
+  {
+    platform: "claude",
     label: ".claude.json / .mcp.json",
     generatedPath: (context) => join(context.outputDir, "claude", ".claude.json"),
     // Claude Code reads MCP servers from two different files depending on scope:


### PR DESCRIPTION
Register settings.local.json as a preserved native config with a JSON overlay so the existing file is the base, and skip it in the generic platform copy that previously overwrote it wholesale.