### PR TITLE
fix(docs): address review findings on the demo tabs

### DIFF
--- a/docs/.vitepress/theme/components/CliDemo.vue
+++ b/docs/.vitepress/theme/components/CliDemo.vue
@@ -65,7 +65,14 @@ watch(lines, () => {
   });
 });
 
-onMounted(() => run(0));
+onMounted(() => {
+  if (matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    // Show the finished transcript instead of typing it out.
+    lines.value = SCRIPT.map((s) => ({ kind: s.kind, mark: MARKS[s.kind], text: s.text }));
+    return;
+  }
+  run(0);
+});
 onUnmounted(() => {
   alive = false;
   clearTimeout(timer);

--- a/docs/.vitepress/theme/components/DemoTabs.vue
+++ b/docs/.vitepress/theme/components/DemoTabs.vue
@@ -1,8 +1,10 @@
 <script setup>
-import { ref } from "vue";
+import { ref, defineAsyncComponent } from "vue";
 
 import CliDemo from "./CliDemo.vue";
-import TuiDemo from "./TuiDemo.vue";
+
+// Async so the ~120KB frame JSON lands in its own chunk instead of every page bundle.
+const TuiDemo = defineAsyncComponent(() => import("./TuiDemo.vue"));
 
 const TABS = [
   { id: "cli", label: "cli", title: "~/projects/acme — ulis", hint: "zsh" },
@@ -20,11 +22,14 @@ const tab = () => TABS.find((t) => t.id === active.value);
         <button
           v-for="t in TABS"
           :key="t.id"
+          :id="`ul-demo-tab-${t.id}`"
           class="ul-demo-tab"
           :class="{ 'ul-demo-tab-active': active === t.id }"
           role="tab"
           type="button"
           :aria-selected="active === t.id"
+          :aria-controls="`ul-demo-panel-${t.id}`"
+          :tabindex="active === t.id ? 0 : -1"
           @click="active = t.id"
         >
           {{ t.label }}
@@ -39,8 +44,10 @@ const tab = () => TABS.find((t) => t.id === active.value);
         <span class="ul-tl-title">{{ tab().title }}</span>
         <span class="ul-tl-shell">{{ tab().hint }}</span>
       </div>
-      <CliDemo v-if="active === 'cli'" />
-      <TuiDemo v-else />
+      <div :id="`ul-demo-panel-${active}`" role="tabpanel" :aria-labelledby="`ul-demo-tab-${active}`">
+        <CliDemo v-if="active === 'cli'" />
+        <TuiDemo v-else />
+      </div>
     </div>
   </div>
 </template>
@@ -145,15 +152,6 @@ const tab = () => TABS.find((t) => t.id === active.value);
   color: var(--ul-accent);
   background: rgba(53, 149, 184, 0.1);
 }
-.ul-demo-cmd {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 0 18px;
-  font-size: 12.5px;
-  color: var(--ul-dim);
-}
 .ul-tl-title {
   flex: 1;
   text-align: center;
@@ -167,6 +165,13 @@ const tab = () => TABS.find((t) => t.id === active.value);
 
 @media (max-width: 640px) {
   .ul-tl-title {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ul-terminal-scan {
+    animation: none;
     display: none;
   }
 }

--- a/docs/.vitepress/theme/components/TuiDemo.vue
+++ b/docs/.vitepress/theme/components/TuiDemo.vue
@@ -26,7 +26,9 @@ function advance() {
   }, RESOLVED[index.value].hold);
 }
 
-onMounted(advance);
+onMounted(() => {
+  if (!matchMedia("(prefers-reduced-motion: reduce)").matches) advance();
+});
 onUnmounted(() => clearTimeout(timer));
 </script>
 
@@ -50,12 +52,11 @@ onUnmounted(() => clearTimeout(timer));
   background: #0d1117;
   height: var(--ul-demo-h);
   display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden auto;
+  overflow: auto;
 }
 .ul-tui-screen {
-  margin: 0;
+  /* auto margins centre the frame but still let it scroll when wider than the card */
+  margin: auto;
   padding: 0;
   background: none;
   border: none;
@@ -64,7 +65,6 @@ onUnmounted(() => clearTimeout(timer));
   line-height: 1.32;
   color: #c9d1d9;
   white-space: pre;
-  overflow: hidden;
 }
 .ul-tui-row {
   display: block;


### PR DESCRIPTION
- honour prefers-reduced-motion in both demos and the scanline
- let the 100-column TUI frame scroll horizontally on narrow screens
- complete tab/tabpanel ARIA wiring with a roving tabindex
- load TuiDemo (and its ~120KB frame JSON) as an async chunk
- drop the unused .ul-demo-cmd rule